### PR TITLE
Fix affiliation filter false-matching exclusion clauses

### DIFF
--- a/src/hooks/useFilterData.js
+++ b/src/hooks/useFilterData.js
@@ -58,7 +58,8 @@ const useFilterData = (loading, data, columns, searchQuery) => {
               return parsedQuery.exclude[fullOrAbbreviatedColumn].every((match) => {
                 if (column === 'affiliation') {
                   const abbrev = AFFILIATION_ABBREVIATIONS[match];
-                  return !row[column].includes(match) && !(abbrev && row[column].includes(abbrev));
+                  const affiliationText = row[column].replace(/\(except[^)]*\)/g, '');
+                  return !affiliationText.includes(match) && !(abbrev && affiliationText.includes(abbrev));
                 }
                 return !row[column].includes(match);
               })
@@ -76,7 +77,8 @@ const useFilterData = (loading, data, columns, searchQuery) => {
               return parsedQuery[fullOrAbbreviatedColumn].every((match) => {
                 if (column === 'affiliation') {
                   const abbrev = AFFILIATION_ABBREVIATIONS[match];
-                  return row[column].includes(match) || (abbrev && row[column].includes(abbrev));
+                  const affiliationText = row[column].replace(/\(except[^)]*\)/g, '');
+                  return affiliationText.includes(match) || (abbrev && affiliationText.includes(abbrev));
                 }
                 return row[column].includes(match);
               })

--- a/src/tests/hooks/useFilterData.test.js
+++ b/src/tests/hooks/useFilterData.test.js
@@ -85,3 +85,30 @@ describe('useFilterData — affiliation filter', () => {
     expect(names).toContain('Bajor');
   });
 });
+
+describe('useFilterData — affiliation exclusion clause filter', () => {
+  const borgMission = makeCard({ name: 'Borg Mission', type: 'mission', affiliation: '[bor]' });
+  const anyExceptBorgMission = makeCard({
+    name: 'Hromi Cluster',
+    type: 'mission',
+    affiliation: 'any affiliation (except [bor]) may attempt this mission.',
+  });
+  const fedMission = makeCard({ name: 'Establish Relations', type: 'mission', affiliation: '[fed]' });
+
+  const allCards = [borgMission, anyExceptBorgMission, fedMission];
+
+  it('does not return missions where borg appears only in an exclusion clause for affiliation:borg', () => {
+    const result = getFiltered(allCards, 'affiliation:borg');
+    const names = result.map(c => c.name);
+    expect(names).toContain('Borg Mission');
+    expect(names).not.toContain('Hromi Cluster');
+  });
+
+  it('does not exclude missions where borg appears only in an exclusion clause for -affiliation:borg', () => {
+    const result = getFiltered(allCards, '-a:borg');
+    const names = result.map(c => c.name);
+    expect(names).not.toContain('Borg Mission');
+    expect(names).toContain('Hromi Cluster');
+    expect(names).toContain('Establish Relations');
+  });
+});


### PR DESCRIPTION
Fixes #25

Missions like "Any affiliation (except [Bor]) may attempt this mission."
were incorrectly appearing when filtering for affiliation:borg, because
the filter found [bor] in the text even though it only appeared in an
exclusion clause.

Strip "(except ...)" clauses from the affiliation text before matching,
for both inclusion and exclusion filters. Also add tests covering the
new behavior.

https://claude.ai/code/session_01R2VXWjqSGswrw3nwrpjSQX