### PR TITLE
Fix failing SearchResults test after hover image DOM structure change

### DIFF
--- a/src/tests/components/SearchResults.test.tsx
+++ b/src/tests/components/SearchResults.test.tsx
@@ -255,11 +255,14 @@ describe('SearchResults', () => {
 
       // The portal container div should have position fixed and left < targetRect.left
       const hoverImg = screen.getAllByAltText('Test Card')[1];
-      const container = hoverImg.parentElement!.parentElement!;
-      expect(container.style.left).toBeTruthy();
+      let container: HTMLElement | null = hoverImg.parentElement;
+      while (container && !container.style.left) {
+        container = container.parentElement;
+      }
+      expect(container?.style.left).toBeTruthy();
       // Left position = targetRect.left - imageWidth - 10 = 50 - 458 - 10 = -418
       // This validates the "position to left" branch was taken
-      expect(parseInt(container.style.left)).toBeLessThan(50);
+      expect(parseInt(container!.style.left)).toBeLessThan(50);
     });
   });
 


### PR DESCRIPTION
A previous commit added a <div className="relative"> wrapper around the
hover image (for inset shadow overlay support), so the test needed to
traverse one extra level up to reach the styled container div.

https://claude.ai/code/session_01Jn6gLP2toiDuNuze6DYpCJ