### PR TITLE
Make filter pills editable (closes #38)

### DIFF
--- a/src/components/SearchPills.tsx
+++ b/src/components/SearchPills.tsx
@@ -202,6 +202,7 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
   const filters = useMemo(() => parseFilters(searchQuery), [searchQuery]);
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [editingFilter, setEditingFilter] = useState<ParsedFilter | null>(null);
   const [showMoreFilters, setShowMoreFilters] = useState(false);
   const [selectedRangeFilter, setSelectedRangeFilter] = useState<string | null>(null);
   const [rangeMin, setRangeMin] = useState(5);
@@ -219,6 +220,15 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
   const popoverContentRef = useRef<HTMLDivElement>(null);
   const [popoverLeftOffset, setPopoverLeftOffset] = useState(0);
 
+  // Returns the base query to build from when adding a filter.
+  // In edit mode, removes the filter being replaced first.
+  const getBaseQuery = () => {
+    if (editingFilter) {
+      return removeFilter(searchQuery, editingFilter);
+    }
+    return searchQuery;
+  };
+
   const handleRemoveFilter = (filter: ParsedFilter) => {
     const newQuery = removeFilter(searchQuery, filter);
     setSearchQuery(newQuery);
@@ -226,6 +236,7 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
 
   const handleAddFilterClick = () => {
     setIsPopoverOpen(true);
+    setEditingFilter(null);
     onPopoverOpenChange?.(true);
     setShowMoreFilters(false);
     setSelectedRangeFilter(null);
@@ -233,6 +244,7 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
 
   const closePopover = () => {
     setIsPopoverOpen(false);
+    setEditingFilter(null);
     onPopoverOpenChange?.(false);
     setShowMoreFilters(false);
     setSelectedRangeFilter(null);
@@ -244,6 +256,52 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
     setTypeSearch('');
     setActiveSimpleTypeahead(null);
     setSimpleTypeaheadSearch('');
+  };
+
+  const handleEditFilter = (filter: ParsedFilter) => {
+    // Reset all popover states before opening in edit mode
+    setShowMoreFilters(false);
+    setSelectedRangeFilter(null);
+    setShowSkillsTypeahead(false);
+    setSkillsSearch('');
+    setShowAffiliationTypeahead(false);
+    setAffiliationSearch('');
+    setShowTypeTypeahead(false);
+    setTypeSearch('');
+    setActiveSimpleTypeahead(null);
+    setSimpleTypeaheadSearch('');
+
+    setEditingFilter(filter);
+
+    if (filter.isRange) {
+      const expandedKey = expandKeyword(filter.key);
+      setSelectedRangeFilter(expandedKey);
+      // Parse existing range values (e.g. "2-5", "3-", "-5")
+      const dashIdx = filter.value.indexOf('-');
+      if (dashIdx >= 0) {
+        const minStr = filter.value.slice(0, dashIdx);
+        const maxStr = filter.value.slice(dashIdx + 1);
+        setRangeMin(minStr ? parseInt(minStr, 10) : (RANGE_DEFAULTS[expandedKey] ?? 5));
+        setRangeMax(maxStr ? parseInt(maxStr, 10) : (RANGE_DEFAULTS[expandedKey] ?? 5));
+      }
+    } else {
+      const fullKey = expandKeyword(filter.key);
+      if (fullKey === 'skills') {
+        setShowSkillsTypeahead(true);
+      } else if (fullKey === 'affiliation') {
+        setShowAffiliationTypeahead(true);
+      } else if (fullKey === 'type') {
+        setShowTypeTypeahead(true);
+      } else {
+        const simpleConfig = SIMPLE_TYPEAHEAD_CONFIGS[fullKey];
+        if (simpleConfig) {
+          setActiveSimpleTypeahead(simpleConfig);
+        }
+      }
+    }
+
+    setIsPopoverOpen(true);
+    onPopoverOpenChange?.(true);
   };
 
   const handleSelectTextFilter = (fieldName: string) => {
@@ -268,26 +326,30 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
       setSimpleTypeaheadSearch('');
       return;
     }
-    const prefix = searchQuery.trim() ? `${searchQuery.trim()} ` : '';
+    const base = getBaseQuery();
+    const prefix = base.trim() ? `${base.trim()} ` : '';
     setSearchQuery(`${prefix}${fieldName}:`);
     closePopover();
   };
 
   const handleSelectSkill = (skill: string) => {
-    const prefix = searchQuery.trim() ? `${searchQuery.trim()} ` : '';
+    const base = getBaseQuery();
+    const prefix = base.trim() ? `${base.trim()} ` : '';
     setSearchQuery(`${prefix}skills:${skill}`);
     closePopover();
   };
 
   const handleSelectAffiliation = (value: string) => {
-    const prefix = searchQuery.trim() ? `${searchQuery.trim()} ` : '';
+    const base = getBaseQuery();
+    const prefix = base.trim() ? `${base.trim()} ` : '';
     const needsQuotes = value.includes(' ');
     setSearchQuery(`${prefix}affiliation:${needsQuotes ? `"${value}"` : value}`);
     closePopover();
   };
 
   const handleSelectType = (value: string) => {
-    const prefix = searchQuery.trim() ? `${searchQuery.trim()} ` : '';
+    const base = getBaseQuery();
+    const prefix = base.trim() ? `${base.trim()} ` : '';
     setSearchQuery(`${prefix}type:${value}`);
     closePopover();
   };
@@ -300,7 +362,8 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
   };
 
   const handleAddRangeFilter = () => {
-    const prefix = searchQuery.trim() ? `${searchQuery.trim()} ` : '';
+    const base = getBaseQuery();
+    const prefix = base.trim() ? `${base.trim()} ` : '';
     setSearchQuery(`${prefix}${selectedRangeFilter}:${rangeMin}-${rangeMax}`);
     closePopover();
   };
@@ -344,7 +407,7 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
   }, [isPopoverOpen]);
 
   return (
-    <div className="flex flex-wrap items-center gap-2 mt-3">
+    <div ref={popoverRef} className="relative flex flex-wrap items-center gap-2 mt-3">
       {filters.map((filter, index) => (
         <span
           key={`${filter.rawText}-${index}`}
@@ -352,9 +415,13 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
                      bg-accent/20 border border-accent/40 rounded-lg
                      text-sm font-mono text-text-primary"
         >
-          <span className={filter.isExclude ? 'text-red-400' : ''}>
+          <button
+            onClick={() => handleEditFilter(filter)}
+            className={filter.isExclude ? 'text-red-400' : ''}
+            aria-label={`Edit ${filter.rawText} filter`}
+          >
             {filter.rawText}
-          </span>
+          </button>
           <button
             onClick={() => handleRemoveFilter(filter)}
             className="text-text-muted hover:text-text-primary transition-colors ml-0.5"
@@ -365,231 +432,272 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
         </span>
       ))}
 
-      <div className="relative" ref={popoverRef}>
-        <button
-          onClick={handleAddFilterClick}
-          className="filter-chip-add"
-          aria-label="Add filter"
-        >
-          + Add filter
-        </button>
+      <button
+        onClick={handleAddFilterClick}
+        className="filter-chip-add"
+        aria-label="Add filter"
+      >
+        + Add filter
+      </button>
 
-        {isPopoverOpen && (
-          <div
-            ref={popoverContentRef}
-            className="syntax-panel absolute left-0 top-full mt-1 z-20 min-w-[240px] !bg-[#131713] border-white/[0.1]"
-            style={popoverLeftOffset !== 0 ? { left: popoverLeftOffset } : undefined}
-          >
-            {selectedRangeFilter ? (
-              <>
-                <div className="syntax-panel-title">{selectedRangeFilter}</div>
-                <div className="flex items-center gap-4 my-2">
-                  <div className="flex flex-col items-center gap-1">
-                    <span className="text-xs text-text-muted">Min</span>
-                    <div className="flex items-center gap-2">
-                      <button
-                        onClick={() => setRangeMin((m) => m - 1)}
-                        className="btn-icon btn-icon-sm"
-                        aria-label="−"
-                      >
-                        −
-                      </button>
-                      <span className="font-mono text-lg min-w-[2ch] text-center">{rangeMin}</span>
-                      <button
-                        onClick={() => setRangeMin((m) => m + 1)}
-                        className="btn-icon btn-icon-sm"
-                        aria-label="+"
-                      >
-                        +
-                      </button>
-                    </div>
-                  </div>
-                  <div className="flex flex-col items-center gap-1">
-                    <span className="text-xs text-text-muted">Max</span>
-                    <div className="flex items-center gap-2">
-                      <button
-                        onClick={() => setRangeMax((m) => m - 1)}
-                        className="btn-icon btn-icon-sm"
-                        aria-label="−"
-                      >
-                        −
-                      </button>
-                      <span className="font-mono text-lg min-w-[2ch] text-center">{rangeMax}</span>
-                      <button
-                        onClick={() => setRangeMax((m) => m + 1)}
-                        className="btn-icon btn-icon-sm"
-                        aria-label="+"
-                      >
-                        +
-                      </button>
-                    </div>
+      {isPopoverOpen && (
+        <div
+          ref={popoverContentRef}
+          className="syntax-panel absolute left-0 top-full mt-1 z-20 min-w-[240px] !bg-[#131713] border-white/[0.1]"
+          style={popoverLeftOffset !== 0 ? { left: popoverLeftOffset } : undefined}
+        >
+          {selectedRangeFilter ? (
+            <>
+              <div className="syntax-panel-title">{selectedRangeFilter}</div>
+              <div className="flex items-center gap-4 my-2">
+                <div className="flex flex-col items-center gap-1">
+                  <span className="text-xs text-text-muted">Min</span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => setRangeMin((m) => m - 1)}
+                      className="btn-icon btn-icon-sm"
+                      aria-label="−"
+                    >
+                      −
+                    </button>
+                    <span className="font-mono text-lg min-w-[2ch] text-center">{rangeMin}</span>
+                    <button
+                      onClick={() => setRangeMin((m) => m + 1)}
+                      className="btn-icon btn-icon-sm"
+                      aria-label="+"
+                    >
+                      +
+                    </button>
                   </div>
                 </div>
-                <button
-                  onClick={handleAddRangeFilter}
-                  className="btn-primary mt-3 w-full"
-                  aria-label={`Add ${selectedRangeFilter}:${rangeMin}-${rangeMax}`}
-                >
-                  Add {selectedRangeFilter}:{rangeMin}-{rangeMax}
-                </button>
-              </>
-            ) : showSkillsTypeahead ? (
-              <>
-                <div className="syntax-panel-title">Select a Skill</div>
-                <input
-                  type="text"
-                  value={skillsSearch}
-                  onChange={(e) => setSkillsSearch(e.target.value)}
-                  placeholder="Search skills..."
-                  className="w-full px-2 py-1 mb-2 text-[16px] bg-white/[0.05] border border-white/10
-                             rounded-md text-text-primary placeholder-text-muted outline-none
-                             focus:border-accent/50"
-                  autoFocus
-                />
-                {(() => {
-                  const filtered = SKILLS.filter((s) =>
-                    s.toLowerCase().includes(skillsSearch.toLowerCase())
-                  );
-                  return filtered.length > 0 ? (
-                    <ul className="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
-                      {filtered.map((skill) => (
-                        <li
-                          key={skill}
-                          role="option"
-                          aria-selected={false}
-                          onClick={() => handleSelectSkill(skill)}
-                          className="px-2 py-1 text-sm text-text-secondary hover:text-text-primary
-                                     hover:bg-white/[0.08] rounded cursor-pointer transition-colors"
-                        >
-                          {skill}
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p className="text-xs text-text-muted py-1">No skills match</p>
-                  );
-                })()}
-              </>
-            ) : showAffiliationTypeahead ? (
-              <>
-                <div className="syntax-panel-title">Select an Affiliation</div>
-                <input
-                  type="text"
-                  value={affiliationSearch}
-                  onChange={(e) => setAffiliationSearch(e.target.value)}
-                  placeholder="Search affiliations..."
-                  className="w-full px-2 py-1 mb-2 text-[16px] bg-white/[0.05] border border-white/10
-                             rounded-md text-text-primary placeholder-text-muted outline-none
-                             focus:border-accent/50"
-                  autoFocus
-                />
-                {(() => {
-                  const filtered = AFFILIATIONS.filter((a) =>
-                    a.label.toLowerCase().includes(affiliationSearch.toLowerCase())
-                  );
-                  return filtered.length > 0 ? (
-                    <ul className="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
-                      {filtered.map((affiliation) => (
-                        <li
-                          key={affiliation.value}
-                          role="option"
-                          aria-selected={false}
-                          onClick={() => handleSelectAffiliation(affiliation.value)}
-                          className="px-2 py-1 text-sm text-text-secondary hover:text-text-primary
-                                     hover:bg-white/[0.08] rounded cursor-pointer transition-colors"
-                        >
-                          {affiliation.label}
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p className="text-xs text-text-muted py-1">No affiliations match</p>
-                  );
-                })()}
-              </>
-            ) : showTypeTypeahead ? (
-              <>
-                <div className="syntax-panel-title">Select a Type</div>
-                <input
-                  type="text"
-                  value={typeSearch}
-                  onChange={(e) => setTypeSearch(e.target.value)}
-                  placeholder="Search types..."
-                  className="w-full px-2 py-1 mb-2 text-[16px] bg-white/[0.05] border border-white/10
-                             rounded-md text-text-primary placeholder-text-muted outline-none
-                             focus:border-accent/50"
-                  autoFocus
-                />
-                {(() => {
-                  const filtered = CARD_TYPES.filter((t) =>
-                    t.toLowerCase().includes(typeSearch.toLowerCase())
-                  );
-                  return filtered.length > 0 ? (
-                    <ul className="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
-                      {filtered.map((cardType) => (
-                        <li
-                          key={cardType}
-                          role="option"
-                          aria-selected={false}
-                          onClick={() => handleSelectType(cardType)}
-                          className="px-2 py-1 text-sm text-text-secondary hover:text-text-primary
-                                     hover:bg-white/[0.08] rounded cursor-pointer transition-colors"
-                        >
-                          {cardType}
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p className="text-xs text-text-muted py-1">No types match</p>
-                  );
-                })()}
-              </>
-            ) : activeSimpleTypeahead ? (
-              <>
-                <div className="syntax-panel-title">{activeSimpleTypeahead.title}</div>
-                <input
-                  type="text"
-                  value={simpleTypeaheadSearch}
-                  onChange={(e) => setSimpleTypeaheadSearch(e.target.value)}
-                  placeholder={activeSimpleTypeahead.placeholder}
-                  className="w-full px-2 py-1 mb-2 text-[16px] bg-white/[0.05] border border-white/10
-                             rounded-md text-text-primary placeholder-text-muted outline-none
-                             focus:border-accent/50"
-                  autoFocus
-                />
-                {(() => {
-                  const filtered = activeSimpleTypeahead.options.filter((o) =>
-                    o.toLowerCase().includes(simpleTypeaheadSearch.toLowerCase())
-                  );
-                  return filtered.length > 0 ? (
-                    <ul className="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
-                      {filtered.map((option) => (
-                        <li
-                          key={option}
-                          role="option"
-                          aria-selected={false}
-                          onClick={() => {
-                            const prefix = searchQuery.trim() ? `${searchQuery.trim()} ` : '';
-                            setSearchQuery(`${prefix}${activeSimpleTypeahead.field}:${option}`);
-                            closePopover();
-                          }}
-                          className="px-2 py-1 text-sm text-text-secondary hover:text-text-primary
-                                     hover:bg-white/[0.08] rounded cursor-pointer transition-colors"
-                        >
-                          {option}
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p className="text-xs text-text-muted py-1">{activeSimpleTypeahead.noMatchText}</p>
-                  );
-                })()}
-              </>
-            ) : (
-              <>
-                <div className="syntax-panel-title">Text Filters</div>
-                <div className="flex flex-wrap gap-1.5 mb-2">
-                  {QUICK_TEXT_FILTERS.map((filter) => (
+                <div className="flex flex-col items-center gap-1">
+                  <span className="text-xs text-text-muted">Max</span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => setRangeMax((m) => m - 1)}
+                      className="btn-icon btn-icon-sm"
+                      aria-label="−"
+                    >
+                      −
+                    </button>
+                    <span className="font-mono text-lg min-w-[2ch] text-center">{rangeMax}</span>
+                    <button
+                      onClick={() => setRangeMax((m) => m + 1)}
+                      className="btn-icon btn-icon-sm"
+                      aria-label="+"
+                    >
+                      +
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <button
+                onClick={handleAddRangeFilter}
+                className="btn-primary mt-3 w-full"
+                aria-label={`Add ${selectedRangeFilter}:${rangeMin}-${rangeMax}`}
+              >
+                Add {selectedRangeFilter}:{rangeMin}-{rangeMax}
+              </button>
+            </>
+          ) : showSkillsTypeahead ? (
+            <>
+              <div className="syntax-panel-title">Select a Skill</div>
+              <input
+                type="text"
+                value={skillsSearch}
+                onChange={(e) => setSkillsSearch(e.target.value)}
+                placeholder="Search skills..."
+                className="w-full px-2 py-1 mb-2 text-[16px] bg-white/[0.05] border border-white/10
+                           rounded-md text-text-primary placeholder-text-muted outline-none
+                           focus:border-accent/50"
+                autoFocus
+              />
+              {(() => {
+                const filtered = SKILLS.filter((s) =>
+                  s.toLowerCase().includes(skillsSearch.toLowerCase())
+                );
+                return filtered.length > 0 ? (
+                  <ul className="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
+                    {filtered.map((skill) => (
+                      <li
+                        key={skill}
+                        role="option"
+                        aria-selected={false}
+                        onClick={() => handleSelectSkill(skill)}
+                        className="px-2 py-1 text-sm text-text-secondary hover:text-text-primary
+                                   hover:bg-white/[0.08] rounded cursor-pointer transition-colors"
+                      >
+                        {skill}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-text-muted py-1">No skills match</p>
+                );
+              })()}
+            </>
+          ) : showAffiliationTypeahead ? (
+            <>
+              <div className="syntax-panel-title">Select an Affiliation</div>
+              <input
+                type="text"
+                value={affiliationSearch}
+                onChange={(e) => setAffiliationSearch(e.target.value)}
+                placeholder="Search affiliations..."
+                className="w-full px-2 py-1 mb-2 text-[16px] bg-white/[0.05] border border-white/10
+                           rounded-md text-text-primary placeholder-text-muted outline-none
+                           focus:border-accent/50"
+                autoFocus
+              />
+              {(() => {
+                const filtered = AFFILIATIONS.filter((a) =>
+                  a.label.toLowerCase().includes(affiliationSearch.toLowerCase())
+                );
+                return filtered.length > 0 ? (
+                  <ul className="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
+                    {filtered.map((affiliation) => (
+                      <li
+                        key={affiliation.value}
+                        role="option"
+                        aria-selected={false}
+                        onClick={() => handleSelectAffiliation(affiliation.value)}
+                        className="px-2 py-1 text-sm text-text-secondary hover:text-text-primary
+                                   hover:bg-white/[0.08] rounded cursor-pointer transition-colors"
+                      >
+                        {affiliation.label}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-text-muted py-1">No affiliations match</p>
+                );
+              })()}
+            </>
+          ) : showTypeTypeahead ? (
+            <>
+              <div className="syntax-panel-title">Select a Type</div>
+              <input
+                type="text"
+                value={typeSearch}
+                onChange={(e) => setTypeSearch(e.target.value)}
+                placeholder="Search types..."
+                className="w-full px-2 py-1 mb-2 text-[16px] bg-white/[0.05] border border-white/10
+                           rounded-md text-text-primary placeholder-text-muted outline-none
+                           focus:border-accent/50"
+                autoFocus
+              />
+              {(() => {
+                const filtered = CARD_TYPES.filter((t) =>
+                  t.toLowerCase().includes(typeSearch.toLowerCase())
+                );
+                return filtered.length > 0 ? (
+                  <ul className="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
+                    {filtered.map((cardType) => (
+                      <li
+                        key={cardType}
+                        role="option"
+                        aria-selected={false}
+                        onClick={() => handleSelectType(cardType)}
+                        className="px-2 py-1 text-sm text-text-secondary hover:text-text-primary
+                                   hover:bg-white/[0.08] rounded cursor-pointer transition-colors"
+                      >
+                        {cardType}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-text-muted py-1">No types match</p>
+                );
+              })()}
+            </>
+          ) : activeSimpleTypeahead ? (
+            <>
+              <div className="syntax-panel-title">{activeSimpleTypeahead.title}</div>
+              <input
+                type="text"
+                value={simpleTypeaheadSearch}
+                onChange={(e) => setSimpleTypeaheadSearch(e.target.value)}
+                placeholder={activeSimpleTypeahead.placeholder}
+                className="w-full px-2 py-1 mb-2 text-[16px] bg-white/[0.05] border border-white/10
+                           rounded-md text-text-primary placeholder-text-muted outline-none
+                           focus:border-accent/50"
+                autoFocus
+              />
+              {(() => {
+                const filtered = activeSimpleTypeahead.options.filter((o) =>
+                  o.toLowerCase().includes(simpleTypeaheadSearch.toLowerCase())
+                );
+                return filtered.length > 0 ? (
+                  <ul className="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
+                    {filtered.map((option) => (
+                      <li
+                        key={option}
+                        role="option"
+                        aria-selected={false}
+                        onClick={() => {
+                          const base = getBaseQuery();
+                          const prefix = base.trim() ? `${base.trim()} ` : '';
+                          setSearchQuery(`${prefix}${activeSimpleTypeahead.field}:${option}`);
+                          closePopover();
+                        }}
+                        className="px-2 py-1 text-sm text-text-secondary hover:text-text-primary
+                                   hover:bg-white/[0.08] rounded cursor-pointer transition-colors"
+                      >
+                        {option}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-text-muted py-1">{activeSimpleTypeahead.noMatchText}</p>
+                );
+              })()}
+            </>
+          ) : (
+            <>
+              <div className="syntax-panel-title">Text Filters</div>
+              <div className="flex flex-wrap gap-1.5 mb-2">
+                {QUICK_TEXT_FILTERS.map((filter) => (
+                  <button
+                    key={filter}
+                    onClick={() => handleSelectTextFilter(filter)}
+                    className="text-xs px-2 py-1 bg-white/[0.05] border border-white/10
+                               rounded-md text-text-secondary hover:text-text-primary
+                               hover:bg-white/[0.08] transition-colors font-mono"
+                    aria-label={`${filter}:`}
+                  >
+                    {filter}:
+                  </button>
+                ))}
+              </div>
+
+              <div className="divider" />
+              <div className="syntax-panel-title">Range Filters</div>
+              <div className="flex flex-wrap gap-1.5 mb-2">
+                {Object.keys(RANGE_DEFAULTS).map((filter) => (
+                  <button
+                    key={filter}
+                    onClick={() => handleSelectRangeFilter(filter)}
+                    className="text-xs px-2 py-1 bg-white/[0.05] border border-white/10
+                               rounded-md text-text-secondary hover:text-text-primary
+                               hover:bg-white/[0.08] transition-colors font-mono"
+                    aria-label={`${filter}:`}
+                  >
+                    {filter}:
+                  </button>
+                ))}
+              </div>
+
+              <div className="divider" />
+              <button
+                onClick={() => setShowMoreFilters((prev) => !prev)}
+                className="btn-ghost text-xs w-full text-left px-0"
+              >
+                {showMoreFilters ? '▼ Less' : '▶ More text filters'}
+              </button>
+
+              {showMoreFilters && (
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  {MORE_TEXT_FILTERS.map((filter) => (
                     <button
                       key={filter}
                       onClick={() => handleSelectTextFilter(filter)}
@@ -602,53 +710,11 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
                     </button>
                   ))}
                 </div>
-
-                <div className="divider" />
-                <div className="syntax-panel-title">Range Filters</div>
-                <div className="flex flex-wrap gap-1.5 mb-2">
-                  {Object.keys(RANGE_DEFAULTS).map((filter) => (
-                    <button
-                      key={filter}
-                      onClick={() => handleSelectRangeFilter(filter)}
-                      className="text-xs px-2 py-1 bg-white/[0.05] border border-white/10
-                                 rounded-md text-text-secondary hover:text-text-primary
-                                 hover:bg-white/[0.08] transition-colors font-mono"
-                      aria-label={`${filter}:`}
-                    >
-                      {filter}:
-                    </button>
-                  ))}
-                </div>
-
-                <div className="divider" />
-                <button
-                  onClick={() => setShowMoreFilters((prev) => !prev)}
-                  className="btn-ghost text-xs w-full text-left px-0"
-                >
-                  {showMoreFilters ? '▼ Less' : '▶ More text filters'}
-                </button>
-
-                {showMoreFilters && (
-                  <div className="flex flex-wrap gap-1.5 mt-2">
-                    {MORE_TEXT_FILTERS.map((filter) => (
-                      <button
-                        key={filter}
-                        onClick={() => handleSelectTextFilter(filter)}
-                        className="text-xs px-2 py-1 bg-white/[0.05] border border-white/10
-                                   rounded-md text-text-secondary hover:text-text-primary
-                                   hover:bg-white/[0.08] transition-colors font-mono"
-                        aria-label={`${filter}:`}
-                      >
-                        {filter}:
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        )}
-      </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/tests/components/SearchPills.test.tsx
+++ b/src/tests/components/SearchPills.test.tsx
@@ -538,6 +538,112 @@ describe('SearchPills', () => {
       expect(screen.getByRole('button', { name: /remove name:picard filter/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /remove type:personnel filter/i })).toBeInTheDocument();
     });
+
+    it('edit buttons have appropriate aria labels', () => {
+      const setSearchQuery = jest.fn();
+      render(<SearchPills searchQuery="name:Picard type:personnel" setSearchQuery={setSearchQuery} />);
+
+      expect(screen.getByRole('button', { name: /edit name:picard filter/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /edit type:personnel filter/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('edit filter functionality', () => {
+    it('clicking pill text opens the popover', () => {
+      render(<SearchPills searchQuery="type:personnel" setSearchQuery={jest.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: /edit type:personnel filter/i }));
+      expect(screen.getByPlaceholderText(/search types/i)).toBeInTheDocument();
+    });
+
+    it('clicking a skills pill opens the skills typeahead', () => {
+      render(<SearchPills searchQuery="skills:Diplomacy" setSearchQuery={jest.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: /edit skills:diplomacy filter/i }));
+      expect(screen.getByPlaceholderText(/search skills/i)).toBeInTheDocument();
+    });
+
+    it('clicking an affiliation pill opens the affiliation typeahead', () => {
+      render(<SearchPills searchQuery="affiliation:Klingon" setSearchQuery={jest.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: /edit affiliation:klingon filter/i }));
+      expect(screen.getByPlaceholderText(/search affiliations/i)).toBeInTheDocument();
+    });
+
+    it('clicking a range pill opens the range stepper with pre-populated values', () => {
+      render(<SearchPills searchQuery="cost:2-5" setSearchQuery={jest.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: /edit cost:2-5 filter/i }));
+      expect(screen.getByText('Min')).toBeInTheDocument();
+      expect(screen.getByText('Max')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+
+    it('editing a type filter replaces the old filter', () => {
+      const setSearchQuery = jest.fn();
+      render(<SearchPills searchQuery="type:personnel" setSearchQuery={setSearchQuery} />);
+      fireEvent.click(screen.getByRole('button', { name: /edit type:personnel filter/i }));
+      fireEvent.click(screen.getByRole('option', { name: /^Ship$/i }));
+      expect(setSearchQuery).toHaveBeenCalledWith('type:Ship');
+    });
+
+    it('editing a skills filter replaces the old filter', () => {
+      const setSearchQuery = jest.fn();
+      render(<SearchPills searchQuery="skills:Diplomacy" setSearchQuery={setSearchQuery} />);
+      fireEvent.click(screen.getByRole('button', { name: /edit skills:diplomacy filter/i }));
+      fireEvent.click(screen.getByRole('option', { name: /^Security$/i }));
+      expect(setSearchQuery).toHaveBeenCalledWith('skills:Security');
+    });
+
+    it('editing an affiliation filter replaces the old filter', () => {
+      const setSearchQuery = jest.fn();
+      render(<SearchPills searchQuery="affiliation:Klingon" setSearchQuery={setSearchQuery} />);
+      fireEvent.click(screen.getByRole('button', { name: /edit affiliation:klingon filter/i }));
+      fireEvent.click(screen.getByRole('option', { name: /^Romulan$/i }));
+      expect(setSearchQuery).toHaveBeenCalledWith('affiliation:Romulan');
+    });
+
+    it('editing a range filter replaces the old filter', () => {
+      const setSearchQuery = jest.fn();
+      render(<SearchPills searchQuery="cost:2-5" setSearchQuery={setSearchQuery} />);
+      fireEvent.click(screen.getByRole('button', { name: /edit cost:2-5 filter/i }));
+      // Increment max to make a distinguishable change (5 → 6)
+      const incrementButtons = screen.getAllByRole('button', { name: '+' });
+      fireEvent.click(incrementButtons[1]); // second + is for max
+      fireEvent.click(screen.getByRole('button', { name: /add cost/i }));
+      const newQuery = setSearchQuery.mock.calls[0][0];
+      expect(newQuery).not.toContain('cost:2-5');
+      expect(newQuery).toContain('cost:2-6');
+    });
+
+    it('editing one filter preserves other filters', () => {
+      const setSearchQuery = jest.fn();
+      render(
+        <SearchPills
+          searchQuery="type:personnel skills:Diplomacy"
+          setSearchQuery={setSearchQuery}
+        />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /edit type:personnel filter/i }));
+      fireEvent.click(screen.getByRole('option', { name: /^Ship$/i }));
+      const newQuery = setSearchQuery.mock.calls[0][0];
+      expect(newQuery).toContain('skills:Diplomacy');
+      expect(newQuery).toContain('type:Ship');
+      expect(newQuery).not.toContain('type:personnel');
+    });
+
+    it('closes popover after editing a filter', () => {
+      render(<SearchPills searchQuery="type:personnel" setSearchQuery={jest.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: /edit type:personnel filter/i }));
+      fireEvent.click(screen.getByRole('option', { name: /^Ship$/i }));
+      expect(screen.queryByPlaceholderText(/search types/i)).not.toBeInTheDocument();
+    });
+
+    it('clicking add filter after editing opens a fresh popover', () => {
+      render(<SearchPills searchQuery="type:personnel" setSearchQuery={jest.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: /edit type:personnel filter/i }));
+      expect(screen.getByPlaceholderText(/search types/i)).toBeInTheDocument();
+      fireEvent.keyDown(document, { key: 'Escape' });
+      fireEvent.click(screen.getByRole('button', { name: /add filter/i }));
+      expect(screen.getByText('Text Filters')).toBeInTheDocument();
+    });
   });
 
   describe('rendering structure', () => {


### PR DESCRIPTION
Clicking the text of a filter pill now opens the same popover dialog
used when adding a filter, pre-populated with the existing filter's
values. Selecting a new value replaces the old filter in the query
rather than appending a duplicate.

- Range pills pre-populate the stepper with existing min/max values
- Skills/affiliation/type pills open their respective typeaheads
- Simple typeahead pills (quadrant, staff, hof, etc.) open their menus
- Other text filter pills open the main filter menu
- The popover click-outside detection is extended to cover all pills
  so clicking a pill never accidentally closes the popover first
- All existing tests pass; 12 new tests cover edit behaviour

https://claude.ai/code/session_01JWkVw9zCuURSfw2NTNwszS