### PR TITLE
Fix filter bar overlap by dynamically tracking overlay height

### DIFF
--- a/src/components/CardSearchClient.tsx
+++ b/src/components/CardSearchClient.tsx
@@ -25,7 +25,8 @@ export default function CardSearchClient({ data, columns }: CardSearchClientProp
     const el = overlayRef.current;
     if (!el) return;
     const observer = new ResizeObserver(([entry]) => {
-      setOverlayHeight(entry.contentRect.height);
+      const size = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+      setOverlayHeight(size);
     });
     observer.observe(el);
     return () => observer.disconnect();


### PR DESCRIPTION
Replaces the hardcoded pt-28 content offset with a ResizeObserver on
the fixed overlay element, so content padding always matches the actual
rendered height regardless of how many filter chip rows are present.

https://claude.ai/code/session_01A4Bh1sxDpVMpcpDGnKew3U