### PR TITLE
Add include/exclude toggle to filter popover (closes #46)

### DIFF
--- a/src/components/SearchPills.tsx
+++ b/src/components/SearchPills.tsx
@@ -402,10 +402,29 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
     closePopover();
   };
 
+  const handleToggleMode = (newMode: 'include' | 'exclude') => {
+    if (filterMode === newMode) return;
+    setFilterMode(newMode);
+
+    // When editing an existing filter, immediately re-commit with the new mode
+    // so the search query (and results) update right away.
+    if (editingFilter && !editingFilter.isRange) {
+      const base = removeFilter(searchQuery, editingFilter);
+      const prefix = base.trim() ? `${base.trim()} ` : '';
+      const excludePrefix = newMode === 'exclude' ? '-' : '';
+      const displayKey = expandKeyword(editingFilter.key) || editingFilter.key;
+      const val = editingFilter.value;
+      const needsQuotes = val.includes(' ');
+      const newRawText = `${excludePrefix}${displayKey}:${needsQuotes ? `"${val}"` : val}`;
+      setSearchQuery(`${prefix}${newRawText}`);
+      setEditingFilter({ ...editingFilter, isExclude: newMode === 'exclude', rawText: newRawText });
+    }
+  };
+
   const renderIncludeExcludeToggle = (disabled = false) => (
     <div className="flex gap-1 mb-3">
       <button
-        onClick={() => setFilterMode('include')}
+        onClick={() => handleToggleMode('include')}
         disabled={disabled}
         aria-pressed={filterMode === 'include'}
         className={`text-xs px-2 py-1 rounded-md border transition-colors ${
@@ -417,7 +436,7 @@ export default function SearchPills({ searchQuery, setSearchQuery, onPopoverOpen
         + Include
       </button>
       <button
-        onClick={() => setFilterMode('exclude')}
+        onClick={() => handleToggleMode('exclude')}
         disabled={disabled}
         aria-pressed={filterMode === 'exclude'}
         className={`text-xs px-2 py-1 rounded-md border transition-colors ${

--- a/src/tests/components/SearchPills.test.tsx
+++ b/src/tests/components/SearchPills.test.tsx
@@ -675,6 +675,44 @@ describe('SearchPills', () => {
         expect(screen.getByRole('button', { name: /− exclude/i })).toHaveAttribute('aria-pressed', 'false');
       });
     });
+
+    describe('immediate query update when toggling in edit mode', () => {
+      it('immediately updates query to exclude when toggling to exclude while editing', () => {
+        const setSearchQuery = jest.fn();
+        render(<SearchPills searchQuery="type:personnel" setSearchQuery={setSearchQuery} />);
+        fireEvent.click(screen.getByRole('button', { name: /edit type:personnel filter/i }));
+        fireEvent.click(screen.getByRole('button', { name: /− exclude/i }));
+        expect(setSearchQuery).toHaveBeenCalledWith('-type:personnel');
+      });
+
+      it('immediately updates query to include when toggling back from exclude while editing', () => {
+        const setSearchQuery = jest.fn();
+        render(<SearchPills searchQuery="-type:personnel" setSearchQuery={setSearchQuery} />);
+        fireEvent.click(screen.getByRole('button', { name: /edit -type:personnel filter/i }));
+        fireEvent.click(screen.getByRole('button', { name: /\+ include/i }));
+        expect(setSearchQuery).toHaveBeenCalledWith('type:personnel');
+      });
+
+      it('preserves other filters when toggling mode in edit mode', () => {
+        const setSearchQuery = jest.fn();
+        render(<SearchPills searchQuery="skills:Diplomacy type:personnel" setSearchQuery={setSearchQuery} />);
+        fireEvent.click(screen.getByRole('button', { name: /edit type:personnel filter/i }));
+        fireEvent.click(screen.getByRole('button', { name: /− exclude/i }));
+        const newQuery = setSearchQuery.mock.calls[0][0];
+        expect(newQuery).toContain('-type:personnel');
+        expect(newQuery).toContain('skills:Diplomacy');
+      });
+
+      it('does not update query when toggling while adding (no editingFilter)', () => {
+        const setSearchQuery = jest.fn();
+        render(<SearchPills searchQuery="" setSearchQuery={setSearchQuery} />);
+        fireEvent.click(screen.getByRole('button', { name: /add filter/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^skills:$/i }));
+        fireEvent.click(screen.getByRole('button', { name: /− exclude/i }));
+        // No query update yet — only happens when a value is selected
+        expect(setSearchQuery).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('accessibility', () => {


### PR DESCRIPTION
Adds a small Include / Exclude segmented control at the top of each
filter config view (typeahead and text-input). Clicking Exclude causes
the committed filter to be prefixed with '-', matching the existing
search-box exclusion syntax. Range filters show the toggle in a disabled
(greyed-out) state since exclusion is semantically awkward for ranges.
When editing an existing excluded filter the toggle pre-selects Exclude.
The toggle resets to Include every time the popover is opened fresh.