### PR TITLE
Fix test suite: update filter tests and add ResizeObserver mock

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -3,3 +3,9 @@ import '@testing-library/jest-dom'
 jest.mock('@vercel/analytics', () => ({
   track: jest.fn(),
 }))
+
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}))

--- a/src/tests/app/page.test.tsx
+++ b/src/tests/app/page.test.tsx
@@ -30,7 +30,7 @@ import useFilterData from '../../hooks/useFilterData';
 import useScrollVisibility from '../../hooks/useScrollVisibility';
 
 const mockCardData = [
-  { collectorsinfo: '1R000', originalName: 'Test Card', type: 'mission', name: 'test card' }
+  { collectorsinfo: '1R000', originalName: 'Test Card', type: 'mission', name: 'test card', dilemmatype: '', imagefile: '', mission: '', unique: '' }
 ];
 
 const mockColumns = ['collectorsinfo', 'originalName', 'type', 'name'];

--- a/src/tests/components/SearchPills.test.tsx
+++ b/src/tests/components/SearchPills.test.tsx
@@ -263,8 +263,8 @@ describe('SearchPills', () => {
         const setSearchQuery = jest.fn();
         render(<SearchPills searchQuery="existing" setSearchQuery={setSearchQuery} />);
         fireEvent.click(screen.getByRole('button', { name: /add filter/i }));
-        fireEvent.click(screen.getByRole('button', { name: /^name:$/i }));
-        expect(setSearchQuery).toHaveBeenCalledWith('existing name:');
+        fireEvent.click(screen.getByRole('button', { name: /^icons:$/i }));
+        expect(setSearchQuery).toHaveBeenCalledWith('existing icons:');
         expect(screen.queryByText('Text Filters')).not.toBeInTheDocument();
       });
 
@@ -272,8 +272,8 @@ describe('SearchPills', () => {
         const setSearchQuery = jest.fn();
         render(<SearchPills searchQuery="" setSearchQuery={setSearchQuery} />);
         fireEvent.click(screen.getByRole('button', { name: /add filter/i }));
-        fireEvent.click(screen.getByRole('button', { name: /^name:$/i }));
-        expect(setSearchQuery).toHaveBeenCalledWith('name:');
+        fireEvent.click(screen.getByRole('button', { name: /^icons:$/i }));
+        expect(setSearchQuery).toHaveBeenCalledWith('icons:');
       });
     });
 
@@ -323,10 +323,9 @@ describe('SearchPills', () => {
     });
 
     describe('more filters expansion', () => {
-      it('shows more text filters when expanded', () => {
+      it('shows all text filters together without expansion', () => {
         render(<SearchPills searchQuery="" setSearchQuery={jest.fn()} />);
         fireEvent.click(screen.getByRole('button', { name: /add filter/i }));
-        fireEvent.click(screen.getByText(/more text filters/i));
         expect(screen.getByRole('button', { name: /^gametext:$/i })).toBeInTheDocument();
       });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "types": ["node", "jest"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
This PR updates the test suite to fix failing tests and improve test environment setup. Changes include updating SearchPills filter tests to use the correct filter type, removing an expansion step that's no longer needed, adding a ResizeObserver mock for the test environment, and updating test data to include required fields.

## Key Changes
- **SearchPills tests**: Updated filter selection from `name:` to `icons:` in two test cases to match the current filter behavior
- **Filter expansion test**: Removed the "more text filters" expansion click since all text filters are now shown together without expansion
- **Jest setup**: Added global ResizeObserver mock to prevent errors in tests that use components relying on ResizeObserver API
- **Test data**: Added missing required fields (`dilemmatype`, `imagefile`, `mission`, `unique`) to mock card data in page tests
- **TypeScript config**: Added explicit type declarations for Node and Jest in tsconfig.json for better type checking

## Notable Details
The ResizeObserver mock is necessary because some components in the application use the ResizeObserver API, which is not available in the Jest test environment by default. This prevents "ResizeObserver is not defined" errors during test execution.

https://claude.ai/code/session_01T8CriGHagwYwNc46HD3M2V