### PR TITLE
Fix exclusion filters not working when using full column names (closes #63)

### DIFF
--- a/src/hooks/useFilterData.ts
+++ b/src/hooks/useFilterData.ts
@@ -30,8 +30,11 @@ function toArray(item: string | string[]): string[] {
   }
 }
 
-const colInQuery = (col: string, parsedQuery: ParsedQuery): string =>
-      parsedQuery[col] ? col : (textAbbreviations[col] || rangeAbbreviations[col])
+const colInQuery = (col: string, parsedQuery: ParsedQuery): string => {
+  if (parsedQuery[col]) return col;
+  if (parsedQuery.exclude && parsedQuery.exclude[col]) return col;
+  return textAbbreviations[col] || rangeAbbreviations[col];
+}
 
 
 const useFilterData = (loading: boolean, data: CardRow[], columns: string[], searchQuery: string): CardRow[] => {

--- a/src/tests/hooks/useFilterData.test.ts
+++ b/src/tests/hooks/useFilterData.test.ts
@@ -29,6 +29,27 @@ function getFiltered(data, searchQuery) {
   return result.current;
 }
 
+describe('useFilterData — exclusion filter using full column name', () => {
+  const cmdPersonnel = makeCard({ name: 'Picard', icons: 'cmd', type: 'personnel' });
+  const noIconPersonnel = makeCard({ name: 'Ensign Ro', icons: '', type: 'personnel' });
+  const dualDilemma = makeCard({ name: 'Antedean Assassins', type: 'dilemma', dilemmatype: 'd' });
+  const spaceDilemma = makeCard({ name: 'Spatial Rift', type: 'dilemma', dilemmatype: 's' });
+
+  it('-icons:Cmd excludes personnel with command icons', () => {
+    const result = getFiltered([cmdPersonnel, noIconPersonnel], '-icons:Cmd');
+    const names = result.map(c => c.name);
+    expect(names).not.toContain('Picard');
+    expect(names).toContain('Ensign Ro');
+  });
+
+  it('-dilemmatype:d type:Dilemma excludes dual dilemmas', () => {
+    const result = getFiltered([dualDilemma, spaceDilemma], '-dilemmatype:d type:Dilemma');
+    const names = result.map(c => c.name);
+    expect(names).not.toContain('Antedean Assassins');
+    expect(names).toContain('Spatial Rift');
+  });
+});
+
 describe('useFilterData — affiliation filter', () => {
   const federationPersonnel = makeCard({ name: 'Robin Lefler', affiliation: 'federation' });
   const bajorPersonnel = makeCard({ name: 'Kira Nerys', affiliation: 'bajoran' });


### PR DESCRIPTION
colInQuery only checked parsedQuery[col] (positive filters), so exclusion
filters using full column names like -icons:Cmd or -dilemmatype:d were
silently ignored. The function now also checks parsedQuery.exclude[col] so
it correctly returns the full column name when only an exclusion filter is
present.

https://claude.ai/code/session_01QYyKxiKhrVtZZUpZQ682kX