### PR TITLE
Sort reportsto filter results by type and affiliation (closes #69)

### DIFF
--- a/src/hooks/useFilterData.ts
+++ b/src/hooks/useFilterData.ts
@@ -23,6 +23,14 @@ function isAnyAffiliationMatch(row: CardRow): boolean {
   return row.affiliation.includes('any affiliation');
 }
 
+function getReportsToSortRank(card: CardRow): number {
+  const na = card.affiliation.includes('non-aligned');
+  if (card.type === 'personnel') return na ? 1 : 0;
+  if (card.type === 'ship') return na ? 3 : 2;
+  if (card.type === 'equipment') return 4;
+  return 5;
+}
+
 function toArray(item: string | string[]): string[] {
   if (Array.isArray(item)) {
     return item;
@@ -139,6 +147,11 @@ const useFilterData = (loading: boolean, data: CardRow[], columns: string[], sea
         if (aIsAny === bIsAny) return 0;
         return aIsAny ? 1 : -1;
       });
+    }
+
+    const reportstoCol = colInQuery('reportsto', parsedQuery);
+    if (typeof parsedQuery !== 'string' && parsedQuery[reportstoCol]) {
+      filtered = [...filtered].sort((a, b) => getReportsToSortRank(a) - getReportsToSortRank(b));
     }
 
     if (JSON.stringify(filtered) !== JSON.stringify(filteredData)) {

--- a/src/tests/hooks/useFilterData.test.ts
+++ b/src/tests/hooks/useFilterData.test.ts
@@ -309,3 +309,49 @@ describe('useFilterData — affiliation match sorting order', () => {
     expect(result.map(c => c.name)).toContain('Establish Relations');
   });
 });
+
+describe('useFilterData — reportsto sort order', () => {
+  const tngPersonnel = makeCard({ name: 'TNG Personnel', type: 'personnel', affiliation: 'federation', icons: '[tng]', keywords: '' });
+  const naPersonnel = makeCard({ name: 'NA Personnel', type: 'personnel', affiliation: 'non-aligned', icons: '', keywords: '' });
+  const tngShip = makeCard({ name: 'TNG Ship', type: 'ship', affiliation: 'federation', icons: '[tng]', keywords: '' });
+  const naShip = makeCard({ name: 'NA Ship', type: 'ship', affiliation: 'non-aligned', icons: '', keywords: '' });
+  const equipment = makeCard({ name: 'Equipment', type: 'equipment', affiliation: '', icons: '', keywords: '' });
+
+  // All match 'earth cradle of the federation': [tng] or [e] icon, or NA, or equipment
+  const allCards = [equipment, naShip, tngShip, naPersonnel, tngPersonnel];
+
+  it('sorts reportsto results: non-NA personnel first, then NA personnel, then non-NA ships, then NA ships, then equipment', () => {
+    const result = getFiltered(allCards, 'reportsto:"earth cradle of the federation"');
+    const names = result.map(c => c.name);
+    const tngPersonnelIdx = names.indexOf('TNG Personnel');
+    const naPersonnelIdx = names.indexOf('NA Personnel');
+    const tngShipIdx = names.indexOf('TNG Ship');
+    const naShipIdx = names.indexOf('NA Ship');
+    const equipmentIdx = names.indexOf('Equipment');
+    expect(tngPersonnelIdx).toBeLessThan(naPersonnelIdx);
+    expect(naPersonnelIdx).toBeLessThan(tngShipIdx);
+    expect(tngShipIdx).toBeLessThan(naShipIdx);
+    expect(naShipIdx).toBeLessThan(equipmentIdx);
+  });
+
+  it('preserves relative order within each group', () => {
+    const tngPersonnel2 = makeCard({ name: 'TNG Personnel 2', type: 'personnel', affiliation: 'federation', icons: '[tng]', keywords: '' });
+    const cards = [tngPersonnel2, equipment, tngPersonnel];
+    const result = getFiltered(cards, 'reportsto:"earth cradle of the federation"');
+    const names = result.map(c => c.name);
+    // Both TNG personnel should appear before equipment
+    expect(names.indexOf('TNG Personnel 2')).toBeLessThan(names.indexOf('Equipment'));
+    expect(names.indexOf('TNG Personnel')).toBeLessThan(names.indexOf('Equipment'));
+    // Relative order within group preserved
+    expect(names.indexOf('TNG Personnel 2')).toBeLessThan(names.indexOf('TNG Personnel'));
+  });
+
+  it('does not apply reportsto sort when no reportsto filter is present', () => {
+    // Input order should be preserved (no sort applied)
+    const cards = [equipment, naShip, tngPersonnel];
+    const result = getFiltered(cards, 'type:personnel');
+    // Only tngPersonnel matches, so just verify no error
+    expect(result.map(c => c.name)).toContain('TNG Personnel');
+    expect(result.map(c => c.name)).not.toContain('Equipment');
+  });
+});


### PR DESCRIPTION
When a reportsto filter is active, results are sorted into the order:
non-NA personnel → NA personnel → non-NA ships → NA ships → equipment.
This matches the desired UX from issue #69 (e.g. Earth Cradle: TNG
personnel, Earth personnel, NA personnel, TNG ships, Earth ships, NA
ships, equipment).

https://claude.ai/code/session_01ULMFBvQAnNz3H8c22GhMZF