### PR TITLE
Fix reportsto:"bajor terok nor" to include non-unique Cardassian/Klingon personnel

### DIFF
--- a/src/lib/hqPlayability.ts
+++ b/src/lib/hqPlayability.ts
@@ -13,6 +13,7 @@ type HQPredicate = (card: CardRow) => boolean;
 
 const isNA = (card: CardRow): boolean => card.affiliation.includes('non-aligned');
 const isEquipment = (card: CardRow): boolean => card.type === 'equipment';
+const isNonUnique = (card: CardRow): boolean => card.unique === 'n';
 
 // HQ card names in display (mixed-case) form, used for the typeahead list.
 export const HQ_NAMES: string[] = [
@@ -62,6 +63,7 @@ export const HQ_PLAYABILITY: Record<string, HQPredicate> = {
   // Alliance Headquarters (Bajor Terok Nor)
   // "You may play [AU][Baj] cards, [AU][Car] cards, [AU][Fer] cards,
   //  [AU][Kli] cards, [AU][Non] cards, and equipment at this mission."
+  // Secondary gametext: grants [AU] to each non-unique [Car] and non-unique [Kli] personnel you own.
   'bajor terok nor': (card) =>
     (card.icons.includes('[au]') && (
       card.affiliation.includes('bajoran') ||
@@ -69,7 +71,10 @@ export const HQ_PLAYABILITY: Record<string, HQPredicate> = {
       card.affiliation.includes('ferengi') ||
       card.affiliation.includes('klingon') ||
       card.affiliation.includes('non-aligned')
-    )) || isEquipment(card),
+    )) ||
+    (isNonUnique(card) && card.type === 'personnel' && card.affiliation.includes('cardassian')) ||
+    (isNonUnique(card) && card.type === 'personnel' && card.affiliation.includes('klingon')) ||
+    isEquipment(card),
 
   // Cardassian Headquarters (Cardassia Prime Bastion of Resistance)
   // "You may play [Car] Dissidents, [NA] Dissidents, and [Car] ships, and equipment."

--- a/src/tests/hooks/useFilterData.test.ts
+++ b/src/tests/hooks/useFilterData.test.ts
@@ -310,6 +310,59 @@ describe('useFilterData — affiliation match sorting order', () => {
   });
 });
 
+describe('useFilterData — reportsto:"bajor terok nor" non-unique personnel', () => {
+  const auBajPersonnel = makeCard({ name: 'AU Bajoran', affiliation: 'bajoran', icons: '[au]', unique: 'y', keywords: '' });
+  const auCarPersonnel = makeCard({ name: 'AU Cardassian', affiliation: 'cardassian', icons: '[au]', unique: 'y', keywords: '' });
+  const nonUniqueCarPersonnel = makeCard({ name: 'Non-Unique Cardassian', affiliation: 'cardassian', icons: '', unique: 'n', keywords: '' });
+  const uniqueCarPersonnel = makeCard({ name: 'Unique Cardassian', affiliation: 'cardassian', icons: '', unique: 'y', keywords: '' });
+  const nonUniqueKliPersonnel = makeCard({ name: 'Non-Unique Klingon', affiliation: 'klingon', icons: '', unique: 'n', keywords: '' });
+  const uniqueKliPersonnel = makeCard({ name: 'Unique Klingon', affiliation: 'klingon', icons: '', unique: 'y', keywords: '' });
+  const nonUniqueKliAU = makeCard({ name: 'Non-Unique Klingon AU', affiliation: 'klingon', icons: '[au]', unique: 'n', keywords: '' });
+  const equipment = makeCard({ name: 'Equipment', type: 'equipment', affiliation: '', icons: '', unique: 'n', keywords: '' });
+
+  const allCards = [auBajPersonnel, auCarPersonnel, nonUniqueCarPersonnel, uniqueCarPersonnel, nonUniqueKliPersonnel, uniqueKliPersonnel, nonUniqueKliAU, equipment];
+
+  it('includes [AU] Bajoran personnel', () => {
+    const result = getFiltered(allCards, 'reportsto:"bajor terok nor"');
+    expect(result.map(c => c.name)).toContain('AU Bajoran');
+  });
+
+  it('includes [AU] Cardassian personnel', () => {
+    const result = getFiltered(allCards, 'reportsto:"bajor terok nor"');
+    expect(result.map(c => c.name)).toContain('AU Cardassian');
+  });
+
+  it('includes non-unique Cardassian personnel without [AU] icon', () => {
+    const result = getFiltered(allCards, 'reportsto:"bajor terok nor"');
+    expect(result.map(c => c.name)).toContain('Non-Unique Cardassian');
+  });
+
+  it('excludes unique Cardassian personnel without [AU] icon', () => {
+    const result = getFiltered(allCards, 'reportsto:"bajor terok nor"');
+    expect(result.map(c => c.name)).not.toContain('Unique Cardassian');
+  });
+
+  it('includes non-unique Klingon personnel without [AU] icon', () => {
+    const result = getFiltered(allCards, 'reportsto:"bajor terok nor"');
+    expect(result.map(c => c.name)).toContain('Non-Unique Klingon');
+  });
+
+  it('excludes unique Klingon personnel without [AU] icon', () => {
+    const result = getFiltered(allCards, 'reportsto:"bajor terok nor"');
+    expect(result.map(c => c.name)).not.toContain('Unique Klingon');
+  });
+
+  it('includes non-unique Klingon personnel who also have [AU] icon', () => {
+    const result = getFiltered(allCards, 'reportsto:"bajor terok nor"');
+    expect(result.map(c => c.name)).toContain('Non-Unique Klingon AU');
+  });
+
+  it('includes equipment', () => {
+    const result = getFiltered(allCards, 'reportsto:"bajor terok nor"');
+    expect(result.map(c => c.name)).toContain('Equipment');
+  });
+});
+
 describe('useFilterData — reportsto sort order', () => {
   const tngPersonnel = makeCard({ name: 'TNG Personnel', type: 'personnel', affiliation: 'federation', icons: '[tng]', keywords: '' });
   const naPersonnel = makeCard({ name: 'NA Personnel', type: 'personnel', affiliation: 'non-aligned', icons: '', keywords: '' });


### PR DESCRIPTION
The Bajor: Terok Nor card's secondary gametext grants [AU] to each non-unique
[Car] and non-unique [Kli] personnel you own, so the HQ playability predicate
should include these cards even without a printed [AU] icon.

Adds isNonUnique helper and extends the bajor terok nor predicate accordingly.
Also adds 8 tests covering unique/non-unique distinctions for this HQ.

Fixes #71

https://claude.ai/code/session_017mwJ9ihKQ44tBKMg2ki1qt