### PR TITLE
Add Orias III Hidden Base to reportsto: filter

### DIFF
--- a/src/lib/hqPlayability.ts
+++ b/src/lib/hqPlayability.ts
@@ -35,6 +35,7 @@ export const HQ_NAMES: string[] = [
   'Luna Orpheus Mining Facility',
   'Mouth of the Wormhole Deep Space 9',
   'Mouth of the Wormhole Terok Nor',
+  'Orias III Hidden Base',
   'Qo\'noS Heart of the Empire',
   'Quatal Prime Quiet Mining Colony',
   'Romulus Patient Stronghold',
@@ -154,6 +155,16 @@ export const HQ_PLAYABILITY: Record<string, HQPredicate> = {
   // "You may play [TN] cards, [NA] cards, and equipment at this mission."
   'mouth of the wormhole terok nor': (card) =>
     card.icons.includes('[tn]') || isNA(card) || isEquipment(card),
+
+  // Tal Shiar/Obsidian Order Headquarters (Orias III Hidden Base)
+  // "You may play [Car] Intelligence personnel, [Rom] Intelligence personnel,
+  //  D'deridex-class ships, Keldon-class ships, and equipment at this mission."
+  'orias iii hidden base': (card) =>
+    (card.affiliation.includes('cardassian') && card.type === 'personnel' && card.skills.includes('intelligence')) ||
+    (card.affiliation.includes('romulan') && card.type === 'personnel' && card.skills.includes('intelligence')) ||
+    (card.type === 'ship' && card.class.includes("d'deridex class")) ||
+    (card.type === 'ship' && card.class.includes('keldon class')) ||
+    isEquipment(card),
 
   // Klingon Headquarters (Qo'noS Heart of the Empire)
   // "You may play [Kli] cards, [NA] cards, and equipment at this mission."

--- a/src/tests/hooks/useFilterData.test.ts
+++ b/src/tests/hooks/useFilterData.test.ts
@@ -257,6 +257,65 @@ describe('useFilterData — reportsto filter', () => {
   });
 });
 
+describe('useFilterData — reportsto:"orias iii hidden base"', () => {
+  const carIntelPersonnel = makeCard({ name: 'Enabran Tain', affiliation: 'cardassian', type: 'personnel', skills: 'anthropology intelligence treachery', icons: '', keywords: '', class: '' });
+  const romIntelPersonnel = makeCard({ name: 'Mendak', affiliation: 'romulan', type: 'personnel', skills: 'intelligence leadership officer', icons: '', keywords: '', class: '' });
+  const carNonIntelPersonnel = makeCard({ name: 'Gul Dukat', affiliation: 'cardassian', type: 'personnel', skills: 'diplomacy leadership officer', icons: '', keywords: '', class: '' });
+  const romNonIntelPersonnel = makeCard({ name: 'Cretak', affiliation: 'romulan', type: 'personnel', skills: 'anthropology diplomacy law', icons: '', keywords: '', class: '' });
+  const dderidexShip = makeCard({ name: 'Haakona', affiliation: 'romulan', type: 'ship', skills: '', icons: '', keywords: '', class: "d'deridex class" });
+  const keldonShip = makeCard({ name: 'Keldon', affiliation: 'cardassian', type: 'ship', skills: '', icons: '', keywords: '', class: 'keldon class' });
+  const otherShip = makeCard({ name: 'Galor', affiliation: 'cardassian', type: 'ship', skills: '', icons: '', keywords: '', class: 'galor class' });
+  const equipment = makeCard({ name: 'Phaser', type: 'equipment', affiliation: '', icons: '', keywords: '', class: '' });
+  const nonAligned = makeCard({ name: 'Guinan', affiliation: 'non-aligned', type: 'personnel', skills: 'anthropology', icons: '', keywords: '', class: '' });
+
+  const allCards = [carIntelPersonnel, romIntelPersonnel, carNonIntelPersonnel, romNonIntelPersonnel, dderidexShip, keldonShip, otherShip, equipment, nonAligned];
+
+  it('includes Cardassian Intelligence personnel', () => {
+    const result = getFiltered(allCards, 'reportsto:"orias iii hidden base"');
+    expect(result.map(c => c.name)).toContain('Enabran Tain');
+  });
+
+  it('includes Romulan Intelligence personnel', () => {
+    const result = getFiltered(allCards, 'reportsto:"orias iii hidden base"');
+    expect(result.map(c => c.name)).toContain('Mendak');
+  });
+
+  it('includes D\'deridex-class ships', () => {
+    const result = getFiltered(allCards, 'reportsto:"orias iii hidden base"');
+    expect(result.map(c => c.name)).toContain('Haakona');
+  });
+
+  it('includes Keldon-class ships', () => {
+    const result = getFiltered(allCards, 'reportsto:"orias iii hidden base"');
+    expect(result.map(c => c.name)).toContain('Keldon');
+  });
+
+  it('includes equipment', () => {
+    const result = getFiltered(allCards, 'reportsto:"orias iii hidden base"');
+    expect(result.map(c => c.name)).toContain('Phaser');
+  });
+
+  it('excludes Cardassian personnel without Intelligence', () => {
+    const result = getFiltered(allCards, 'reportsto:"orias iii hidden base"');
+    expect(result.map(c => c.name)).not.toContain('Gul Dukat');
+  });
+
+  it('excludes Romulan personnel without Intelligence', () => {
+    const result = getFiltered(allCards, 'reportsto:"orias iii hidden base"');
+    expect(result.map(c => c.name)).not.toContain('Cretak');
+  });
+
+  it('excludes ships that are not D\'deridex-class or Keldon-class', () => {
+    const result = getFiltered(allCards, 'reportsto:"orias iii hidden base"');
+    expect(result.map(c => c.name)).not.toContain('Galor');
+  });
+
+  it('excludes non-aligned personnel', () => {
+    const result = getFiltered(allCards, 'reportsto:"orias iii hidden base"');
+    expect(result.map(c => c.name)).not.toContain('Guinan');
+  });
+});
+
 describe('useFilterData — affiliation match sorting order', () => {
   const fedPersonnel = makeCard({ name: 'Robin Lefler', affiliation: 'federation' });
   const fedMission = makeCard({ name: 'Establish Relations', type: 'mission', affiliation: '[fed]' });


### PR DESCRIPTION
Adds the Tal Shiar/Obsidian Order headquarters to the HQ_PLAYABILITY
map and HQ_NAMES typeahead list. The predicate allows [Car] and [Rom]
Intelligence personnel, D'deridex-class ships, Keldon-class ships, and
equipment, matching the card's gametext.

Includes comprehensive unit tests covering all allowed card types and
negative cases.

https://claude.ai/code/session_01NqupeDYFBL6uxCY3PGyTLQ