### PR TITLE
Sort personnel before missions in affiliation search results

### DIFF
--- a/src/hooks/useFilterData.ts
+++ b/src/hooks/useFilterData.ts
@@ -31,6 +31,15 @@ function getReportsToSortRank(card: CardRow): number {
   return 5;
 }
 
+function getAffiliationSortRank(card: CardRow): number {
+  const isAny = isAnyAffiliationMatch(card);
+  const baseRank = isAny ? 4 : 0;
+  if (card.type === 'personnel') return baseRank + 0;
+  if (card.type === 'ship') return baseRank + 1;
+  if (card.type === 'equipment') return baseRank + 2;
+  return baseRank + 3;
+}
+
 function toArray(item: string | string[]): string[] {
   if (Array.isArray(item)) {
     return item;
@@ -141,12 +150,7 @@ const useFilterData = (loading: boolean, data: CardRow[], columns: string[], sea
 
     const affiliationCol = colInQuery('affiliation', parsedQuery);
     if (typeof parsedQuery !== 'string' && parsedQuery[affiliationCol]) {
-      filtered = [...filtered].sort((a, b) => {
-        const aIsAny = isAnyAffiliationMatch(a);
-        const bIsAny = isAnyAffiliationMatch(b);
-        if (aIsAny === bIsAny) return 0;
-        return aIsAny ? 1 : -1;
-      });
+      filtered = [...filtered].sort((a, b) => getAffiliationSortRank(a) - getAffiliationSortRank(b));
     }
 
     const reportstoCol = colInQuery('reportsto', parsedQuery);

--- a/src/tests/hooks/useFilterData.test.ts
+++ b/src/tests/hooks/useFilterData.test.ts
@@ -286,12 +286,17 @@ describe('useFilterData — affiliation match sorting order', () => {
     expect(fedPersonnelIdx).toBeLessThan(hromiIdx);
   });
 
-  it('preserves relative order within exact-match group', () => {
+  it('sorts personnel before missions within exact-match group', () => {
     const allCards = [anyOpenMission, fedMission, bajFedMission, fedPersonnel];
     const result = getFiltered(allCards, 'affiliation:federation');
     const names = result.map(c => c.name);
-    expect(names.indexOf('Establish Relations')).toBeLessThan(names.indexOf('Rescue Captives'));
-    expect(names.indexOf('Rescue Captives')).toBeLessThan(names.indexOf('Robin Lefler'));
+    const fedPersonnelIdx = names.indexOf('Robin Lefler');
+    const fedMissionIdx = names.indexOf('Establish Relations');
+    const bajFedMissionIdx = names.indexOf('Rescue Captives');
+    expect(fedPersonnelIdx).toBeLessThan(fedMissionIdx);
+    expect(fedPersonnelIdx).toBeLessThan(bajFedMissionIdx);
+    // Relative order within missions is preserved
+    expect(fedMissionIdx).toBeLessThan(bajFedMissionIdx);
   });
 
   it('preserves relative order within "any affiliation" group', () => {


### PR DESCRIPTION
When filtering by affiliation, results now sort by card type so personnel and ships appear before missions. Any-affiliation matches still sort after specific affiliation matches within each type group.

Fixes #80