### PR TITLE
Add GitHub Action to resolve PR merge conflicts with Claude

### DIFF
--- a/.github/workflows/claude-merge-conflict.yml
+++ b/.github/workflows/claude-merge-conflict.yml
@@ -50,16 +50,16 @@ jobs:
           prompt: |
             Pull request #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}") has merge conflicts with the main branch.
 
-            Your job is to resolve those conflicts. Here's what to do:
+            Your job is to rebase this branch onto main, resolving any conflicts. Here's what to do:
 
             1. Fetch the latest main branch: `git fetch origin main`
-            2. Identify all files with merge conflicts by attempting a merge: `git merge origin/main` (do not abort if it fails — that's expected)
-            3. For each conflicted file, carefully resolve the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) by understanding both sides of the change and producing a correct, logical result that preserves the intent of both the PR branch and main.
+            2. Start an interactive-free rebase: `git rebase origin/main`
+            3. If the rebase pauses on a conflicted commit, for each conflicted file carefully resolve the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) by understanding both sides of the change and producing a correct, logical result that preserves the intent of both the PR branch and main.
             4. Stage the resolved files with `git add`.
-            5. Complete the merge with `git commit -m "Resolve merge conflicts with main"`.
-            6. Push the result: `git push origin HEAD`.
-            7. Leave a comment on PR #${{ github.event.pull_request.number }} summarizing which files had conflicts and how they were resolved.
+            5. Continue the rebase with `git rebase --continue` (repeat steps 3–5 for each conflicted commit).
+            6. Push the rebased branch: `git push --force-with-lease origin HEAD`.
+            7. Leave a comment on PR #${{ github.event.pull_request.number }} summarizing which commits had conflicts and how they were resolved.
 
-            Be careful and precise when resolving conflicts. If a conflict is too ambiguous to resolve safely, leave a clear comment explaining what needs human review instead of guessing.
+            Be careful and precise when resolving conflicts. If a conflict is too ambiguous to resolve safely, abort the rebase with `git rebase --abort` and leave a clear comment explaining what needs human review instead of guessing.
           claude_args: "--max-turns 40 --dangerously-skip-permissions"
           show_full_output: "true"


### PR DESCRIPTION
Triggers on pull_request (opened/synchronize/reopened), polls the GitHub
API until mergeability is computed, then runs Claude Code to resolve
conflict markers and push a clean merge commit when mergeable_state is 'dirty'.

https://claude.ai/code/session_0161XYUHqNn8Qir9x72aXC55