### PR TITLE
fix: move globals.css import to root layout so all pages get styles

### DIFF
--- a/src/app/decks/page.tsx
+++ b/src/app/decks/page.tsx
@@ -1,4 +1,3 @@
-import '../../styles/globals.css';
 import { loadCards } from '../../lib/loadCards';
 import DeckBuilderClient from '../../components/DeckBuilderClient';
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Analytics } from '@vercel/analytics/react';
 import { Providers } from './providers'
+import '../styles/globals.css';
 
 import React from 'react';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from 'react';
-import '../styles/globals.css';
 import { loadCards } from '../lib/loadCards';
 import CardSearchClient from '../components/CardSearchClient';
 


### PR DESCRIPTION
globals.css was imported only in src/app/page.tsx and src/app/decks/page.tsx,
so /decks/practice had no Tailwind styles or custom fonts when visited directly.
Navigating from /decks worked by accident (client-side nav keeps CSS loaded).
Moving the import to the root layout fixes the white background and wrong fonts
on the practice draw page and any future pages.

https://claude.ai/code/session_01AaWLxhjQzxCZyB2vZGQ1wZ