### PR TITLE
fix(og): fix card image display in Discord for preview deployments

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,14 @@ import { loadCards } from '../lib/loadCards';
 import { filterCards } from '../lib/filterCards';
 import CardSearchClient from '../components/CardSearchClient';
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://webula.app';
+// On Vercel preview deployments, NEXT_PUBLIC_BASE_URL (from .env.production) is always
+// 'https://webula.app', so OG image URLs would point to production rather than the preview
+// host where the images actually live. Use VERCEL_URL (set automatically per-deployment)
+// for previews so Discord can fetch the card images from the correct host.
+const BASE_URL =
+  process.env.VERCEL_ENV === 'preview' && process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : (process.env.NEXT_PUBLIC_BASE_URL ?? 'https://webula.app');
 
 export async function generateMetadata(
   { searchParams }: { searchParams: Promise<{ q?: string }> }


### PR DESCRIPTION
Patches #160 (`issue-159-improve-og-preview`) with two fixes for OG image display.

## Root cause

`.env.production` hardcodes `NEXT_PUBLIC_BASE_URL=https://webula.app`. This value is baked into every Vercel build — including preview deployments — so OG image URLs always pointed to `webula.app` rather than the preview host where the card images actually live. Discord tried to fetch the image from `webula.app` and got nothing, resulting in embeds with no image.

## Changes

1. **Use `VERCEL_URL` for preview deployments**: When `VERCEL_ENV === 'preview'`, use `https://${VERCEL_URL}` (set automatically by Vercel per-deployment) as the base URL for OG images, so card images resolve to the correct preview host.
2. **Restore explicit portrait dimensions**: Without `width`/`height` on the `og:image`, Discord renders no image at all. Single-card images use `357×497`.

## Does not close the issue

This PR does not on its own close #159 — it only patches the branch for #160, which will close the issue once merged to main.

## Testing

Use the latest preview URL for this PR: https://webula-git-claude-review-pr-160-keric-fritz-s-team.vercel.app  
(The earlier Discord screenshot used `webula-oqi0bjl69-fritz-s-team.vercel.app` which is a different/older preview deployment.)

https://claude.ai/code/session_01EAeXtSwt1SGyTzx49Mbbw3