### PR TITLE
fix(missionRequirements): fix skill parsing so amber markers actually appear

### DIFF
--- a/src/lib/missionRequirements.ts
+++ b/src/lib/missionRequirements.ts
@@ -521,13 +521,16 @@ export const SPECIES: string[] = [
 
 export function missionRequirements(card: { name: string; skills: string }): Record<string, number> {
   const count: Record<string, number> = {};
-  card.skills.split(',').forEach((token) => {
-    var match = /(\d?)\s(\S+)/.exec(token);
-    if (match !== null) {
-      if (SKILLS.includes(match[2])) {
-        count[match[2]] = (count[match[2]] || 0) + (match[1] ? parseInt(match[1]) : 1);
-      }
+  const skillsLower = new Set(SKILLS.map(s => s.toLowerCase()));
+  // Scan all words in the skills string; handle optional numeric prefix (e.g. "2 Biology")
+  const pattern = /(\d+\s+)?([a-zA-Z]+)/g;
+  let match;
+  while ((match = pattern.exec(card.skills)) !== null) {
+    const skillLower = match[2].toLowerCase();
+    if (skillsLower.has(skillLower)) {
+      const n = match[1] ? parseInt(match[1].trim()) : 1;
+      count[skillLower] = (count[skillLower] || 0) + n;
     }
-  });
+  }
   return count;
 }


### PR DESCRIPTION
Patch on top of PR #166 to fix a bug where the amber mission-requirement markers never appeared in the Personnel skills chart.

## Bug

`useDataFetching` lowercases all card field values, so `row.skills` arrives as e.g. `"transporters, treachery, cunning>34, ..."`. The `missionRequirements` parser compared extracted tokens against the Title-cased `SKILLS` array (`'Transporters'`, `'Treachery'`, …), so every check silently failed and the function always returned `{}`. With no requirements, `hasMissionReqs` was `false` and no markers were rendered.

A secondary bug: the regex `(\d?)\s(\S+)` requires leading whitespace, so the first comma-separated token (no leading space, e.g. `"transporters"`) was never matched either.

## Fix (`src/lib/missionRequirements.ts` only)

Replace the split/regex approach with a global word scan using `/(\d+\s+)?([a-zA-Z]+)/g` that:

- Compares case-insensitively against a lowercased `Set` of `SKILLS`
- Matches all skill words in the string, including those inside complex boolean expressions like `"and (intelligence and leadership or law and officer)"` — all skill names within are found (v1 behaviour per issue spec)
- Still handles numeric prefixes like `"2 biology"`

https://claude.ai/code/session_01G1AyQjFKGnsHHhpX8Lfp2h