### PR TITLE
Add needs-elaboration label from issue comments

### DIFF
--- a/.github/workflows/needs-elaboration-label.yml
+++ b/.github/workflows/needs-elaboration-label.yml
@@ -1,0 +1,22 @@
+name: Add needs-elaboration label
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  label:
+    if: startsWith(github.event.comment.body, 'Elaborate') && github.event.comment.user.login == github.repository_owner
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['needs-elaboration']
+            })


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow `.github/workflows/needs-elaboration-label.yml`
- When a comment starting with `Elaborate` is posted by the repo owner on an issue, the `needs-elaboration` label is automatically added
- Restricted to repo owner only to prevent abuse by other commenters

## Test plan
- [ ] Comment starting with `Elaborate:` on an issue as the repo owner — verify `needs-elaboration` label is added
- [ ] Comment starting with `Elaborate:` as a non-owner — verify label is NOT added
- [ ] Comment not starting with `Elaborate` as the repo owner — verify label is NOT added

Closes #178

https://claude.ai/code/session_01HQAxKPVisRpY3C3W7ywDb3