### PR TITLE
fix: set TypeScript target to es2015 for Set iteration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
         "name": "next"
       }
     ],
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "target": "es2015"
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary

Follow-up fix for #181 (deduplicate OG search results).

- Sets `tsconfig.json` `target` to `es2015` so TypeScript's type checker accepts `Set` iteration (e.g. `set.values()`, `for...of set`)
- The original PR's deduplication code uses a `Set`, which caused a TS type error with the default `es3` target
- `noEmit: true` means Next.js handles all transpilation — this is a type-checker-only change with no runtime impact

## Test plan
- [ ] `yarn build` passes with no TypeScript errors
- [ ] `yarn test` passes

https://claude.ai/code/session_012w2drqSoixDkGcrQruX1VX