### PR TITLE
fix(og): strip *VP suffix before deduplicating card names

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata(
   const query = params.q ?? '';
   const { data, columns } = loadCards();
   const results = query ? filterCards(data, columns, query) : data;
-  const uniqueTitles = [...new Set(results.map((c: any) => c.originalName))];
+  const uniqueTitles = [...new Set(results.map((c: any) => c.originalName.replace(/\s+\*VP$/i, '')))];
   const uniqueCount = uniqueTitles.length;
 
   const title = query


### PR DESCRIPTION
## Summary

- Fix for #181: VP reprints append ` *VP` to card names (e.g. `"Varria Corona Defeat Rogue Borg Vessel *VP"`), so the previous deduplication by `originalName` treated the original and reprint as two distinct cards
- Strip the ` *VP` suffix before building the unique titles `Set`, so a card and its VP reprint count as one unique card in OG/Twitter preview metadata
- Searching for "Varria Corona" now correctly shows "1 card matches" with the card's image, not "2 cards"

## Test plan

- [ ] Search for "Varria Corona" — should show `1 card matches "Varria Corona" in Webula 2e search.` in the OG description, and display the card image rather than the generic fallback

https://claude.ai/code/session_01LAtJiW2g1p4Dc8nBFomALP