### PR TITLE
Add workflow to automatically label issues needing elaboration

### DIFF
--- a/.github/workflows/needs-elaboration-label.yml
+++ b/.github/workflows/needs-elaboration-label.yml
@@ -1,0 +1,28 @@
+name: Add needs-elaboration label
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  label:
+    if: |
+      github.event.comment.user.login == github.repository_owner &&
+      (
+        startsWith(github.event.comment.body, 'Elaborate:') ||
+        startsWith(github.event.comment.body, 'Clarify:') ||
+        startsWith(github.event.comment.body, 'Refine:')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['needs-elaboration']
+            })


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that automatically applies the `needs-elaboration` label to issues when the repository owner posts a comment with specific keywords.

## Key Changes
- Added `.github/workflows/needs-elaboration-label.yml` workflow that:
  - Triggers on new issue comments
  - Checks if the comment author is the repository owner
  - Detects comments starting with "Elaborate:", "Clarify:", or "Refine:"
  - Automatically adds the `needs-elaboration` label to the issue

## Implementation Details
- Uses `actions/github-script@v7` to interact with the GitHub API
- Restricts execution to comments from the repository owner only, preventing misuse
- Requires `issues: write` permission to add labels
- Supports three trigger phrases to accommodate different communication styles

https://claude.ai/code/session_01D5PHuBrdGFZJ6c9BrssT81