### PR TITLE
fix: wrap PostHogPageView in Suspense to fix build error

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,7 +2,7 @@
 import { SessionProvider } from "next-auth/react";
 import posthog from 'posthog-js';
 import { PostHogProvider } from 'posthog-js/react';
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import PostHogPageView from '../components/PostHogPageView';
 
 function PostHogInit({ children }: { children: React.ReactNode }) {
@@ -19,7 +19,9 @@ function PostHogInit({ children }: { children: React.ReactNode }) {
 
   return (
     <PostHogProvider client={posthog}>
-      <PostHogPageView />
+      <Suspense fallback={null}>
+        <PostHogPageView />
+      </Suspense>
       {children}
     </PostHogProvider>
   );


### PR DESCRIPTION
## Summary

Fix-up for #192.

- Wraps `<PostHogPageView />` in `<Suspense fallback={null}>` inside `providers.tsx`

## Problem

`PostHogPageView` calls `useSearchParams()` from `next/navigation`. Next.js requires any component using `useSearchParams()` to be wrapped in a `<Suspense>` boundary, otherwise the build fails with:

```
useSearchParams() should be wrapped in a suspense boundary at page "/decks"
Error occurred prerendering page "/decks"
```

This caused the Vercel deployment in PR #192 to fail.

## Test plan

- [ ] `yarn test` passes
- [ ] `next build` completes without prerender errors

https://claude.ai/code/session_01F3fFc54qZhEz64ycjMarzv