### PR TITLE
fix: posthog track() cleanup in useDataFetching (follow-up for #192)

### DIFF
--- a/src/hooks/useDataFetching.ts
+++ b/src/hooks/useDataFetching.ts
@@ -6,11 +6,6 @@ import posthog from 'posthog-js';
 const nonFilterColumns = ['ImageFile'];
 
 const useDataFetching = () => {
-  const track = (eventName: string) => {
-    if (typeof window !== 'undefined') {
-      posthog.capture(eventName);
-    }
-  };
   const [data, setData] = useState<any[]>([]);
   const [unparsedData, setUnparsedData] = useState('')
   const [filteredData, setFilteredData] = useState<any[]>([]);
@@ -20,10 +15,10 @@ const useDataFetching = () => {
   useEffect(() => {
     console.log(`useEffect ${nonFilterColumns}`);
     const fetchData = async () => {
-      track('useDataFetch.fetchCardsStart');
+      posthog.capture('useDataFetch.fetchCardsStart');
       console.log('fetchData');
       const response = await fetch('/cards_with_processed_columns.txt');
-      track('useDataFetch.fetchCardsFinish');
+      posthog.capture('useDataFetch.fetchCardsFinish');
       const text = await response.text();
       setUnparsedData(text);
       setLoading(false);
@@ -33,7 +28,7 @@ const useDataFetching = () => {
 
   useEffect(() => {
     if (!loading) {
-      track('useDataFetch.parseDataStart');
+      posthog.capture('useDataFetch.parseDataStart');
       const parsedData = d3.tsvParse(unparsedData);
       const formattedData = parsedData.map((row) => {
         const newRow = Object.fromEntries(
@@ -77,10 +72,10 @@ const useDataFetching = () => {
       if (parsedData.length > 0) {
         setColumns(Object.keys(parsedData[0]).map((key) => key.toLowerCase()));
       }
+      posthog.capture('useDataFetching.parseDataFinish');
     }
   }, [unparsedData])
 
-  track('useDataFetching.parseDataFinish');
   return { data, filteredData, setFilteredData, columns, loading };
 };
 


### PR DESCRIPTION
## Summary

Follow-up fix for #192 (PostHog migration) — two issues in `src/hooks/useDataFetching.ts`:

- **`track()` wrapper not removed**: PR #192 described replacing all `track()` calls with `posthog.capture()`, but `useDataFetching.ts` kept a local `track()` helper and continued calling it. This PR removes the wrapper and calls `posthog.capture()` directly, matching the other migrated files.
- **`parseDataFinish` fired on every render**: `track('useDataFetching.parseDataFinish')` was called at the top level of the hook body (outside any `useEffect`), so it fired on every render rather than once after parsing completed. Moved inside the second `useEffect`.

## Test plan

- [x] `yarn test` — all 328 tests pass

https://claude.ai/code/session_01F3fFc54qZhEz64ycjMarzv