### PR TITLE
feat: add one-time Discord slash command registration script

### DIFF
--- a/scripts/register-discord-commands.js
+++ b/scripts/register-discord-commands.js
@@ -28,7 +28,7 @@ if (!APPLICATION_ID || !BOT_TOKEN) {
 const commands = [
   {
     name: 'card',
-    description: 'Look up a Star Trek CCG card',
+    description: 'Search for ST2e cards',
     options: [
       {
         name: 'query',


### PR DESCRIPTION
## Summary

- Adds `scripts/register-discord-commands.js` to register the `/card` slash command with Discord's global commands API
- This is the missing post-merge setup step identified in #197 — the route code from #193 was correct but the command was never registered with Discord

## Context

Issue #197 identified two critical blockers after #193 merged:
1. `DISCORD_PUBLIC_KEY` not set in Vercel — **resolved** (key has since been added to Vercel env vars for all environments)
2. `/card` slash command never registered with Discord — **this PR fixes that**

## Usage

Run once after confirming the Interactions Endpoint URL is set in the Discord Developer Portal:

```bash
DISCORD_APPLICATION_ID=<app-id> DISCORD_BOT_TOKEN=<bot-token> node scripts/register-discord-commands.js
```

Both values are in the Discord Developer Portal (Application ID under "General Information", Bot Token under "Bot"). Re-running is safe — Discord upserts by name.

## Remaining manual step

Before running the script, confirm the Interactions Endpoint URL is set in Discord Developer Portal → your app → General Information → `https://webula.app/api/discord/interactions`. Discord will PING the endpoint immediately on save to verify it — that should now succeed since `DISCORD_PUBLIC_KEY` is set.