### PR TITLE
feat: add agent-browser verification step in implement workflow

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -34,6 +34,9 @@ jobs:
             1. Implement the feature or fix described in the issue, following the implementation plan if one exists.
             2. Make all necessary code changes, following existing code style and conventions in the codebase.
             3. Run `yarn test` to ensure all tests pass. Fix any test failures caused by your changes.
+            3a. Start the dev server with `yarn dev` (runs at http://localhost:3000) and verify your changes look and work correctly by running:
+                `npx agent-browser open http://localhost:3000`
+                Navigate to the relevant pages affected by your changes. Stop the dev server after verification.
             4. Create a new branch named `issue-${{ github.event.issue.number }}-<short-description>` from the current HEAD.
             5. Commit your changes to that branch with a descriptive commit message referencing the issue number.
             6. Push the branch to the remote repository.


### PR DESCRIPTION
## Summary
- Adds a browser verification step (3a) in the `claude-implement.yml` workflow prompt
- Instructs the agent to run `yarn dev` and use `npx agent-browser open http://localhost:3000` to visually verify changes before committing
- Agent stops the dev server after verification

## Test plan
- [ ] Verify the workflow file is syntactically valid YAML
- [ ] Trigger the workflow with a ready-for-dev issue and confirm the agent follows the new verification step

