### PR TITLE
fix: set loadedBrowserDeckName after saving to prevent repeat overwrite warnings (follow-up for #222)

### DIFF
--- a/src/components/DeckBuilderClient.tsx
+++ b/src/components/DeckBuilderClient.tsx
@@ -340,6 +340,7 @@ export default function DeckBuilderClient({ data, columns }: DeckBuilderClientPr
       } else {
         setBrowserDecks([...browserDecks, { name: deckTitle, deck: currentDeck }]);
       }
+      setLoadedBrowserDeckName(deckTitle);
       showSavedFeedback();
     }
   };


### PR DESCRIPTION
## Summary

Follow-up fix for #222. After saving a new deck to browser storage, subsequent saves to the same deck were still triggering the overwrite confirmation because `loadedBrowserDeckName` was only set on *load*, not on *save*.

Reproduction steps from Fritz:
1. Add a card, set a title, save → works fine
2. Add a second card, press save → incorrectly showed overwrite warning

Fix: set `loadedBrowserDeckName` to `deckTitle` after every successful browser save.

## Test plan

- [ ] Add a card, set a title, save to browser → no warning
- [ ] Add another card, save again → no warning
- [ ] Change the deck title to match a *different* existing saved deck → overwrite warning still appears

https://claude.ai/code/session_01S6BbFas2Pf5V7DJhReQhrc