### PR TITLE
fix: resolve Vercel build failure from invalid ESLint rule in featureFlags tests

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,10 +1,10 @@
-const earlyAccessEmails = new Set(
-  (process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS ?? '')
-    .split(',')
-    .map((e) => e.trim().toLowerCase())
-    .filter(Boolean)
-);
-
 export function isEarlyAccessUser(email: string | null | undefined): boolean {
-  return !!email && earlyAccessEmails.has(email.toLowerCase());
+  if (!email) return false;
+  const allowlist = new Set(
+    (process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS ?? '')
+      .split(',')
+      .map((e) => e.trim().toLowerCase())
+      .filter(Boolean)
+  );
+  return allowlist.has(email.toLowerCase());
 }

--- a/src/tests/lib/featureFlags.test.ts
+++ b/src/tests/lib/featureFlags.test.ts
@@ -5,7 +5,6 @@ describe('isEarlyAccessUser', () => {
 
   afterEach(() => {
     process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS = originalEnv;
-    jest.resetModules();
   });
 
   it('returns false for null email', () => {
@@ -19,49 +18,27 @@ describe('isEarlyAccessUser', () => {
   it('returns false for empty string email', () => {
     expect(isEarlyAccessUser('')).toBe(false);
   });
-});
-
-describe('isEarlyAccessUser with allowlist', () => {
-  beforeEach(() => {
-    jest.resetModules();
-  });
 
   it('returns true for an email in the allowlist (case-insensitive)', () => {
-    jest.isolateModules(() => {
-      process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS = 'alice@gmail.com,bob@example.com';
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { isEarlyAccessUser: check } = require('../../lib/featureFlags');
-      expect(check('alice@gmail.com')).toBe(true);
-      expect(check('ALICE@GMAIL.COM')).toBe(true);
-      expect(check('bob@example.com')).toBe(true);
-    });
+    process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS = 'alice@gmail.com,bob@example.com';
+    expect(isEarlyAccessUser('alice@gmail.com')).toBe(true);
+    expect(isEarlyAccessUser('ALICE@GMAIL.COM')).toBe(true);
+    expect(isEarlyAccessUser('bob@example.com')).toBe(true);
   });
 
   it('returns false for an email not in the allowlist', () => {
-    jest.isolateModules(() => {
-      process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS = 'alice@gmail.com';
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { isEarlyAccessUser: check } = require('../../lib/featureFlags');
-      expect(check('charlie@gmail.com')).toBe(false);
-    });
+    process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS = 'alice@gmail.com';
+    expect(isEarlyAccessUser('charlie@gmail.com')).toBe(false);
   });
 
   it('returns false for all emails when env var is empty', () => {
-    jest.isolateModules(() => {
-      process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS = '';
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { isEarlyAccessUser: check } = require('../../lib/featureFlags');
-      expect(check('anyone@gmail.com')).toBe(false);
-    });
+    process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS = '';
+    expect(isEarlyAccessUser('anyone@gmail.com')).toBe(false);
   });
 
   it('handles whitespace around emails in the env var', () => {
-    jest.isolateModules(() => {
-      process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS = ' alice@gmail.com , bob@example.com ';
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { isEarlyAccessUser: check } = require('../../lib/featureFlags');
-      expect(check('alice@gmail.com')).toBe(true);
-      expect(check('bob@example.com')).toBe(true);
-    });
+    process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS = ' alice@gmail.com , bob@example.com ';
+    expect(isEarlyAccessUser('alice@gmail.com')).toBe(true);
+    expect(isEarlyAccessUser('bob@example.com')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fix for the Vercel deployment failure in #234.

**Root cause:** `featureFlags.ts` read `NEXT_PUBLIC_EARLY_ACCESS_EMAILS` at module load time. Tests needed `jest.isolateModules()` + `require()` to reload the module with different env vars. The `// eslint-disable-next-line @typescript-eslint/no-var-requires` comments referenced a rule not present in the ESLint config, causing Next.js to fail the build with:

```
Error: Definition for rule '@typescript-eslint/no-var-requires' was not found.
```

**Fix:** Move env var reading inside `isEarlyAccessUser()` so it's evaluated at call time. Tests can now just set `process.env.NEXT_PUBLIC_EARLY_ACCESS_EMAILS` directly — no `require()` or `isolateModules` needed.

## Test plan
- [x] All 7 `featureFlags` tests pass with the same coverage
- [x] `yarn build` succeeds with no ESLint errors

https://claude.ai/code/session_01AyMcjp1TwQnbF7QTKt7xHW