### PR TITLE
feat: add agent-review workflow for unresolved PR comments

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Pull request #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}") has been labeled "agent-review". Your job is to address all unresolved review comments on this PR.
+            Pull request #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}") has been labeled "agent-review". Your job is to address all unresolved or unaddressed comments on this PR.
 
             1. Fetch all unresolved review comments on the PR:
                `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments`


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/agent-review.yml` triggered when the `agent-review` label is added to a PR
- Claude fetches all unresolved review comments and decides per-thread whether a code change or reply is needed
- Code changes are committed and pushed to the PR branch after running `yarn test`
- Comment-only threads get a direct reply via the GitHub API
- A summary comment is posted on the PR listing what was addressed and what still needs human attention
- The `agent-review` label is removed at the end to prevent re-triggering

## Test plan

- [ ] Add `agent-review` label to a PR with unresolved review comments and verify the workflow triggers
- [ ] Confirm code-change threads result in a commit pushed to the PR branch
- [ ] Confirm comment-only threads get a reply posted
- [ ] Confirm the `agent-review` label is removed after the run
- [ ] Confirm a summary comment is posted on the PR

Closes #229

https://claude.ai/code/session_011MM4RrTkVGK3TnSzYuqy2s