### PR TITLE
fix: promote yarn dev verification to mandatory top-level step

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -34,16 +34,18 @@ jobs:
             1. Implement the feature or fix described in the issue, following the implementation plan if one exists.
             2. Make all necessary code changes, following existing code style and conventions in the codebase.
             3. Run `yarn test` to ensure all tests pass. Fix any test failures caused by your changes.
-            3a. Start the dev server with `yarn dev` (runs at http://localhost:3000) and verify your changes look and work correctly by running:
-                `npx agent-browser open http://localhost:3000`
-                Navigate to the relevant pages affected by your changes. Stop the dev server after verification.
-            4. Create a new branch named `issue-${{ github.event.issue.number }}-<short-description>` from the current HEAD.
-            5. Commit your changes to that branch with a descriptive commit message referencing the issue number.
-            6. Push the branch to the remote repository.
-            7. Open a pull request targeting the main branch with:
+            4. You MUST start the dev server with `yarn dev` (runs at http://localhost:3000) and visually verify your changes by running:
+               `npx agent-browser open http://localhost:3000`
+               Navigate to the relevant pages affected by your changes. Stop the dev server after verification.
+               If `yarn dev` fails to start or `agent-browser` encounters errors, include the full error output in the PR body under a "## Dev Server Issues" section. Do NOT skip this step if errors occur — report them.
+            5. Create a new branch named `issue-${{ github.event.issue.number }}-<short-description>` from the current HEAD.
+            6. Commit your changes to that branch with a descriptive commit message referencing the issue number.
+            7. Push the branch to the remote repository.
+            8. Open a pull request targeting the main branch with:
                - Title summarizing the change
                - Body that closes issue #${{ github.event.issue.number }} (include "Closes #${{ github.event.issue.number }}" in the PR body)
                - A brief summary of what was changed and why
+               - A "## Visual Verification" section describing which pages you visited and what you confirmed looked correct
 
             Be thorough but focused. Only change what is necessary to implement the issue. Reference the AGENTS.md file for project conventions and commands.
           claude_args: "--max-turns 80 --dangerously-skip-permissions"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,13 @@ The script:
 
 The script is idempotent — safe to re-run after every card data update.
 
+## PR Requirements
+
+All PRs from automated agents MUST include:
+- Visual verification via `yarn dev` + `agent-browser` before opening the PR
+- A `## Visual Verification` section in the PR body describing which pages were visited and what was confirmed
+- If the dev server or browser fails, a `## Dev Server Issues` section with the full error output (do NOT skip or omit this step)
+
 ## Fixing bugs
 When asked to fix a bug do your best to write a test that fails without the bug fix. Weigh up the cost and brittleness of writing the test and comment in the PR with the circumstances that made you feel like you couldn't write a useful test. 
 


### PR DESCRIPTION
## Summary

- Promotes `yarn dev` + `agent-browser` verification from sub-point `3a` to a proper top-level step 4 with "You MUST" language
- Requires a `## Visual Verification` section in every PR body, creating accountability
- Adds explicit failure handling: if dev server or browser errors occur, agents must report them under `## Dev Server Issues` (not silently skip)
- Adds a `## PR Requirements` section to `AGENTS.md` as a second enforcement source

## What changed

**`.github/workflows/claude-implement.yml`** — renumbered steps, upgraded language, added PR body requirement and failure-case instructions.

**`AGENTS.md`** — new `## PR Requirements` section reinforcing the visual verification mandate.

## Visual Verification

This PR only modifies the workflow prompt and AGENTS.md (no application code), so there is nothing to verify visually in the running app. The changes are a text/config edit.

Closes #288