### PR TITLE
fix: allow vercel[bot] to trigger Vercel preview check workflow

### DIFF
--- a/.github/workflows/vercel-preview-check.yml
+++ b/.github/workflows/vercel-preview-check.yml
@@ -29,6 +29,7 @@ jobs:
         uses: anthropics/claude-code-action@v1.0.70
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "vercel[bot]"
           prompt: |
             Vercel has posted or updated a deployment-ready comment on PR #${{ github.event.issue.number }}.
 


### PR DESCRIPTION
## Summary

- Add `allowed_bots: "vercel[bot]"` to the `claude-code-action` step in `vercel-preview-check.yml`

## Problem

`claude-code-action` blocks bot-initiated workflows by default as a security measure. Since `vercel-preview-check.yml` triggers on `issue_comment` events posted by `vercel[bot]`, every run was failing immediately with:

> Action failed with error: Workflow initiated by non-human actor: vercel (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

See failing run: https://github.com/iftheshoefritz/webula/actions/runs/23647003669

## Fix

Added `allowed_bots: "vercel[bot]"` to explicitly whitelist the Vercel bot for this workflow.

## Visual Verification

This is a workflow-only change — no app routes are affected, no preview links are relevant.

https://claude.ai/code/session_01F6yxsZ549C66t8bQx9rWdv