### PR TITLE
Add workflow to record outcome on closed issues

### DIFF
--- a/.github/workflows/claude-issue-outcome.yml
+++ b/.github/workflows/claude-issue-outcome.yml
@@ -40,8 +40,8 @@ jobs:
                to get commit messages and changed files.
 
             3. Write a concise outcome summary (2–5 bullet points) covering:
-               - What was changed and why
-               - Which files were modified
+               - What (especially functionality) was changed
+               - Which files were modified (list only names)
                - The merge date of the PR(s)
 
             4. If no linked PRs are found, note "No linked PRs found" in the outcome.


### PR DESCRIPTION
## Summary

Closes #329

- Adds `.github/workflows/claude-issue-outcome.yml` triggered on `issues: closed`
- Uses `anthropics/claude-code-action@v1.0.70` (consistent with other workflows) to inspect linked merged PRs via `gh pr list` and `gh pr view`
- Prepends an `## Outcome` section with UTC close timestamp to the issue body, keeping the original body intact below it
- Guards against issues with no linked PRs by noting "No linked PRs found"

## Visual Verification

This PR only adds a GitHub Actions workflow file — there are no UI changes and no application code was modified. No dev server verification is applicable.

## Dev Server Issues

N/A — workflow-only change.

https://claude.ai/code/session_01LdpkaZYpTTumgzCSjgACCK