### PR TITLE
feat: add missionBranchSelections state (issue #338 step 2)

### DIFF
--- a/src/components/DeckBuilderClient.tsx
+++ b/src/components/DeckBuilderClient.tsx
@@ -147,6 +147,11 @@ export default function DeckBuilderClient({ data, columns }: DeckBuilderClientPr
   const currentDeck = isFixture ? fixtureCurrentDeck : localCurrentDeck;
   const setCurrentDeck = isFixture ? setFixtureCurrentDeck : setLocalCurrentDeck;
   const [deckTitle, setDeckTitle] = useLocalStorage<string>('deckTitle', '');
+  // Per-mission chosen OR branch index (0-based). Absent = all branches included (conservative default).
+  const [missionBranchSelections, setMissionBranchSelections] = useLocalStorage<Record<string, number | null>>(
+    'missionBranchSelections',
+    {}
+  );
   const [deckFile, setDeckFile] = useLocalStorage<{ id: string | null; name: string }>('deckFile', { id: null, name: 'My deck' });
   const [analysisCollapsed, setAnalysisCollapsed] = useLocalStorage<Record<string, boolean>>('analysisCollapsed', {
     'Personnel skills': true,
@@ -256,6 +261,7 @@ export default function DeckBuilderClient({ data, columns }: DeckBuilderClientPr
     setCurrentDeck({});
     setDeckTitle('');
     setDeckFile({ id: null, name: 'My deck' });
+    setMissionBranchSelections({});
   };
 
   const handleFileLoad = (name: string, contents: string, piles?: DeckPile[]) => {
@@ -266,6 +272,7 @@ export default function DeckBuilderClient({ data, columns }: DeckBuilderClientPr
     setCurrentDeck(next);
     if (name && !piles) {
       setDeckTitle(name.replace('.txt', ''));
+      setMissionBranchSelections({});
     }
     posthog.capture('deckBuilder.handleFileLoad.finish', { lines: Object.keys(currentDeck).length });
   };


### PR DESCRIPTION
## Summary

Part of #338. Builds on #343.

Adds a `missionBranchSelections` localStorage key to persist the user's chosen OR branch per mission. This is the schema/state prerequisite for the aggregation and UI steps that follow.

- New `useLocalStorage<Record<string, number | null>>('missionBranchSelections', {})` state
- Key is the card's `name` field; value is the chosen branch index (0-based) or `null` for "all branches" (conservative default)
- Resets to `{}` on `clearDeck()` and on full deck file load (`handleFileLoad` without a pile merge), so stale selections from a previous deck are never applied to a different set of missions
- Backwards compatible: older code without this key simply ignores it

## Test plan

- [x] Existing suite: 506 tests passing — no regressions

## Visual Verification

Pure state addition, no visible UI change in this step.

https://claude.ai/code/session_01DYGmBMr8JNJthxgwNeQbpn