### PR TITLE
Use agent-browser to fetch external URLs in triage and architecture workflows

### DIFF
--- a/.github/workflows/claude-architecture.yml
+++ b/.github/workflows/claude-architecture.yml
@@ -28,7 +28,15 @@ jobs:
           prompt: |
             GitHub issue #${{ github.event.issue.number }} ("${{ github.event.issue.title }}") has been labeled "architecture-discussion" and requires a thorough architectural analysis of the codebase.
 
-            Review issue #${{ github.event.issue.number }}, its body, and all existing comments carefully. Identify every unanswered question and every piece of unspecified or speculative conjecture (e.g. "I think...", "maybe...", "it might be...", "not sure if..."). Then:
+            Review issue #${{ github.event.issue.number }}, its body, and all existing comments carefully.
+
+            If the issue body or comments contain external URLs, fetch their content using agent-browser
+            before proceeding — this is essential for questions that reference external documentation
+            or live deployments:
+              npx agent-browser open <url>
+              npx agent-browser get text
+
+            Identify every unanswered question and every piece of unspecified or speculative conjecture (e.g. "I think...", "maybe...", "it might be...", "not sure if..."). Then:
 
             1. For each unanswered question, investigate the actual codebase to find a concrete answer.
                Reference specific file paths and line numbers where relevant.

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -28,7 +28,15 @@ jobs:
           prompt: |
             GitHub issue #${{ github.event.issue.number }} ("${{ github.event.issue.title }}") has been labeled "needs-elaboration" and requires your analysis.
 
-            Review issue #${{ github.event.issue.number }}, its body, and all existing comments carefully. Then:
+            Review issue #${{ github.event.issue.number }}, its body, and all existing comments carefully.
+
+            If the issue body or comments contain external URLs, fetch their content using agent-browser
+            before proceeding — this is essential for questions that reference external documentation
+            or live deployments:
+              npx agent-browser open <url>
+              npx agent-browser get text
+
+            Then:
 
             1. Answer any open questions posed in the issue or its comments.
             2. Write a clear implementation plan describing what changes would need to be made


### PR DESCRIPTION
## Summary

- `WebFetch` is disabled by default in `claude-code-action` agent mode (the mode used by all workflows here), so agents can't read external URLs referenced in issues
- `agent-browser` (Vercel Labs) has no URL restrictions and can navigate to external URLs
- Adds `npx agent-browser open <url> && npx agent-browser get text` instructions to `claude-triage.yml` and `claude-architecture.yml`, so agents fetch any external links in issue bodies before proceeding with analysis

This unblocks issues like #364, which asks a question about external PostHog documentation and references a live Vercel URL.

See #377 for the full investigation.

## Visual Verification

No app code changed — workflow YAML files only. No dev server verification needed.

https://claude.ai/code/session_01EgkU7oT4xBZvwXWMhYb3ZH