### PR TITLE
feat: capture server-side errors in PostHog via Next.js instrumentation hook

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  experimental: { instrumentationHook: true },
 }
 
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next-auth": "^4.24.5",
     "postcss": "^8.4.21",
     "posthog-js": "^1.362.0",
+    "posthog-node": "^5.29.2",
     "react": "18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "18.2.0",

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -3,19 +3,20 @@ import { PostHog } from 'posthog-node';
 // Required by Next.js 14 instrumentation hook — called once on server startup
 export function register() {}
 
-export function onRequestError(
+export async function onRequestError(
   err: { digest: string } & Error,
   request: Request,
   context: { routerKind: string; routePath: string; routeType: string }
 ) {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return; // edge runtime not supported
-  const client = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+  if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return; // PostHog disabled (e.g. local dev)
+  const client = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   });
-  client.captureException(err, undefined, {
+  // captureExceptionImmediate sends the event immediately and returns a Promise,
+  // which Next.js will await — appropriate for per-request hooks in serverless
+  await client.captureExceptionImmediate(err, undefined, {
     route: context.routePath,
     routeType: context.routeType,
   });
-  // flush synchronously before the function exits
-  return client.shutdown();
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,21 @@
+import { PostHog } from 'posthog-node';
+
+// Required by Next.js 14 instrumentation hook — called once on server startup
+export function register() {}
+
+export function onRequestError(
+  err: { digest: string } & Error,
+  request: Request,
+  context: { routerKind: string; routePath: string; routeType: string }
+) {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return; // edge runtime not supported
+  const client = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+  });
+  client.captureException(err, undefined, {
+    route: context.routePath,
+    routeType: context.routeType,
+  });
+  // flush synchronously before the function exits
+  return client.shutdown();
+}

--- a/src/tests/instrumentation.test.ts
+++ b/src/tests/instrumentation.test.ts
@@ -3,15 +3,12 @@
  */
 
 jest.mock('posthog-node', () => {
-  const mockCaptureException = jest.fn();
-  const mockShutdown = jest.fn().mockResolvedValue(undefined);
+  const mockCaptureExceptionImmediate = jest.fn().mockResolvedValue(undefined);
   const MockPostHog = jest.fn().mockImplementation(() => ({
-    captureException: mockCaptureException,
-    shutdown: mockShutdown,
+    captureExceptionImmediate: mockCaptureExceptionImmediate,
   }));
   // Attach spies to the constructor so tests can access them
-  (MockPostHog as any).__mockCaptureException = mockCaptureException;
-  (MockPostHog as any).__mockShutdown = mockShutdown;
+  (MockPostHog as any).__mockCaptureExceptionImmediate = mockCaptureExceptionImmediate;
   return { PostHog: MockPostHog };
 });
 
@@ -20,8 +17,7 @@ import { onRequestError } from '../instrumentation';
 
 const MockPostHog = PostHog as jest.MockedClass<typeof PostHog>;
 const getMockInstance = () => MockPostHog.mock.results[0]?.value as {
-  captureException: jest.Mock;
-  shutdown: jest.Mock;
+  captureExceptionImmediate: jest.Mock;
 };
 
 const makeError = (message: string): { digest: string } & Error => {
@@ -59,64 +55,63 @@ describe('onRequestError', () => {
       process.env.NEXT_RUNTIME = 'nodejs';
     });
 
-    it('constructs PostHog with the correct key and host', () => {
+    it('constructs PostHog with the correct key and host', async () => {
       const err = makeError('test error');
-      onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
+      await onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
 
       expect(MockPostHog).toHaveBeenCalledWith('phc_test_key', {
         host: 'https://eu.i.posthog.com',
       });
     });
 
-    it('calls captureException with the error and route context', () => {
+    it('calls captureExceptionImmediate with the error and route context', async () => {
       const err = makeError('test error');
       const context = makeContext({ routePath: '/api/some-route', routeType: 'route' });
-      onRequestError(err, new Request('http://localhost/api/some-route'), context);
+      await onRequestError(err, new Request('http://localhost/api/some-route'), context);
 
       const instance = getMockInstance();
-      expect(instance.captureException).toHaveBeenCalledWith(err, undefined, {
+      expect(instance.captureExceptionImmediate).toHaveBeenCalledWith(err, undefined, {
         route: '/api/some-route',
         routeType: 'route',
       });
     });
 
-    it('returns client.shutdown() to flush events before function exits', () => {
+    it('awaits captureExceptionImmediate so the event is sent before the hook returns', async () => {
       const err = makeError('test error');
-      const result = onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
+      await onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
 
       const instance = getMockInstance();
-      expect(instance.shutdown).toHaveBeenCalled();
-      expect(result).toBe(instance.shutdown.mock.results[0].value);
+      expect(instance.captureExceptionImmediate).toHaveBeenCalled();
     });
   });
 
   describe('when NEXT_RUNTIME is not nodejs', () => {
-    it('returns early and does not call captureException on edge runtime', () => {
+    it('returns early and does not call captureExceptionImmediate on edge runtime', async () => {
       process.env.NEXT_RUNTIME = 'edge';
       const err = makeError('test error');
-      onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
+      await onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
 
       expect(MockPostHog).not.toHaveBeenCalled();
     });
 
-    it('returns early and does not call captureException when runtime is undefined', () => {
+    it('returns early and does not call captureExceptionImmediate when runtime is undefined', async () => {
       delete process.env.NEXT_RUNTIME;
       const err = makeError('test error');
-      onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
+      await onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
 
       expect(MockPostHog).not.toHaveBeenCalled();
     });
   });
 
   describe('when NEXT_PUBLIC_POSTHOG_KEY is undefined', () => {
-    it('does not throw (graceful no-op since PostHog is disabled in local dev)', () => {
+    it('returns early without constructing PostHog (graceful no-op in local dev)', async () => {
       process.env.NEXT_RUNTIME = 'nodejs';
       delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
       const err = makeError('test error');
 
-      expect(() => {
-        onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
-      }).not.toThrow();
+      await onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
+
+      expect(MockPostHog).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/tests/instrumentation.test.ts
+++ b/src/tests/instrumentation.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('posthog-node', () => {
+  const mockCaptureException = jest.fn();
+  const mockShutdown = jest.fn().mockResolvedValue(undefined);
+  const MockPostHog = jest.fn().mockImplementation(() => ({
+    captureException: mockCaptureException,
+    shutdown: mockShutdown,
+  }));
+  // Attach spies to the constructor so tests can access them
+  (MockPostHog as any).__mockCaptureException = mockCaptureException;
+  (MockPostHog as any).__mockShutdown = mockShutdown;
+  return { PostHog: MockPostHog };
+});
+
+import { PostHog } from 'posthog-node';
+import { onRequestError } from '../instrumentation';
+
+const MockPostHog = PostHog as jest.MockedClass<typeof PostHog>;
+const getMockInstance = () => MockPostHog.mock.results[0]?.value as {
+  captureException: jest.Mock;
+  shutdown: jest.Mock;
+};
+
+const makeError = (message: string): { digest: string } & Error => {
+  const err = new Error(message) as { digest: string } & Error;
+  err.digest = 'test-digest';
+  return err;
+};
+
+const makeContext = (overrides = {}) => ({
+  routerKind: 'App Router',
+  routePath: '/api/test-error',
+  routeType: 'route',
+  ...overrides,
+});
+
+describe('onRequestError', () => {
+  const originalRuntime = process.env.NEXT_RUNTIME;
+  const originalKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const originalHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = 'https://eu.i.posthog.com';
+  });
+
+  afterEach(() => {
+    process.env.NEXT_RUNTIME = originalRuntime;
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = originalKey;
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = originalHost;
+  });
+
+  describe('when NEXT_RUNTIME is nodejs', () => {
+    beforeEach(() => {
+      process.env.NEXT_RUNTIME = 'nodejs';
+    });
+
+    it('constructs PostHog with the correct key and host', () => {
+      const err = makeError('test error');
+      onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
+
+      expect(MockPostHog).toHaveBeenCalledWith('phc_test_key', {
+        host: 'https://eu.i.posthog.com',
+      });
+    });
+
+    it('calls captureException with the error and route context', () => {
+      const err = makeError('test error');
+      const context = makeContext({ routePath: '/api/some-route', routeType: 'route' });
+      onRequestError(err, new Request('http://localhost/api/some-route'), context);
+
+      const instance = getMockInstance();
+      expect(instance.captureException).toHaveBeenCalledWith(err, undefined, {
+        route: '/api/some-route',
+        routeType: 'route',
+      });
+    });
+
+    it('returns client.shutdown() to flush events before function exits', () => {
+      const err = makeError('test error');
+      const result = onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
+
+      const instance = getMockInstance();
+      expect(instance.shutdown).toHaveBeenCalled();
+      expect(result).toBe(instance.shutdown.mock.results[0].value);
+    });
+  });
+
+  describe('when NEXT_RUNTIME is not nodejs', () => {
+    it('returns early and does not call captureException on edge runtime', () => {
+      process.env.NEXT_RUNTIME = 'edge';
+      const err = makeError('test error');
+      onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
+
+      expect(MockPostHog).not.toHaveBeenCalled();
+    });
+
+    it('returns early and does not call captureException when runtime is undefined', () => {
+      delete process.env.NEXT_RUNTIME;
+      const err = makeError('test error');
+      onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
+
+      expect(MockPostHog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when NEXT_PUBLIC_POSTHOG_KEY is undefined', () => {
+    it('does not throw (graceful no-op since PostHog is disabled in local dev)', () => {
+      process.env.NEXT_RUNTIME = 'nodejs';
+      delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+      const err = makeError('test error');
+
+      expect(() => {
+        onRequestError(err, new Request('http://localhost/api/test-error'), makeContext());
+      }).not.toThrow();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1619,6 +1619,11 @@
   dependencies:
     cross-spawn "^7.0.6"
 
+"@posthog/core@1.25.2":
+  version "1.25.2"
+  resolved "https://registry.yarnpkg.com/@posthog/core/-/core-1.25.2.tgz#94a7b7ae44739fa945eaf688126f9af3435473d7"
+  integrity sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==
+
 "@posthog/types@1.362.0":
   version "1.362.0"
   resolved "https://registry.yarnpkg.com/@posthog/types/-/types-1.362.0.tgz#024d2560e5dacae01e4c4eff63d7287704c04432"
@@ -6188,6 +6193,13 @@ posthog-js@^1.362.0:
     query-selector-shadow-dom "^1.0.1"
     web-vitals "^5.1.0"
 
+posthog-node@^5.29.2:
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/posthog-node/-/posthog-node-5.29.2.tgz#081394948c1c7dd9b13f2838d31b09585da4802c"
+  integrity sha512-rI7kkF0XqDc0G1qjx+Hb4iuY9NAlL+XQNoGOpnEpRNTUcXvjY6WlsRGZ9m2whgc39emrrYdszi/YT8wZkr2xsg==
+  dependencies:
+    "@posthog/core" "1.25.2"
+
 preact-render-to-string@^5.1.19:
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz#0ff0c86cd118d30affb825193f18e92bd59d0604"
@@ -6834,16 +6846,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6956,14 +6959,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7593,16 +7589,7 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Closes #387

## Summary

- Adds `posthog-node` as a dependency
- Enables `experimental.instrumentationHook` in `next.config.js` (required for Next.js 14)
- Creates `src/instrumentation.ts` with a `register()` stub (required by Next.js 14) and an `onRequestError` hook that automatically captures all unhandled server-side errors — API routes, Server Components, Server Actions — to PostHog via the Node SDK
- Reuses the existing `NEXT_PUBLIC_POSTHOG_KEY` / `NEXT_PUBLIC_POSTHOG_HOST` env vars (no new secrets needed; `NEXT_PUBLIC_` vars are available server-side too)
- Skips early on the edge runtime (PostHog Node SDK is Node.js only)
- Adds 6 unit tests covering: correct PostHog construction, `captureException` call with route context, `shutdown()` flush, early return on edge/undefined runtime, and graceful no-op when key is absent

## What stays the same

- No changes to any existing API route
- `/api/test-error` keeps throwing — the hook captures it automatically
- All client-side error handling (`ErrorBoundary`, `unhandledrejection` listener) is untouched

## Visual Verification

Started `yarn dev` and confirmed:

- Server started cleanly with `· instrumentationHook` listed under Experiments — no startup errors
- `GET /` → 200
- `GET /decks` → 200
- `GET /test-error` → 200
- `GET /api/test-error` → 500 (intentional — the hook captures this error in production where `NEXT_PUBLIC_POSTHOG_KEY` is set)