### PR TITLE
feat: capture server-side errors in PostHog via onRequestError

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "googleapis": "^129.0.0",
     "lodash": "^4.17.21",
     "next": "^15.3.0",
-    "sharp": "^0.33.5",
     "next-auth": "^4.24.5",
     "postcss": "^8.4.21",
     "posthog-js": "^1.362.0",
+    "posthog-node": "^5.29.2",
     "react": "18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "18.2.0",
@@ -32,6 +32,7 @@
     "react-tooltip": "^5.28.0",
     "react-virtuoso": "^4.18.3",
     "search-query-parser": "^1.6.0",
+    "sharp": "^0.33.5",
     "tailwindcss": "^3.3.1"
   },
   "devDependencies": {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,74 @@
+import type { Instrumentation } from 'next';
+
+/**
+ * Next.js 15 instrumentation hook.
+ *
+ * register() runs once when the server process starts. We leave it empty
+ * because PostHog is created lazily in `onRequestError` (and in
+ * `src/lib/posthogServer.ts`).
+ */
+export function register(): void {
+  // no-op; PostHog client is initialised lazily on first error
+}
+
+/**
+ * Automatically called by Next.js 15+ whenever a request handler throws —
+ * covers App Router route handlers (including `/api/test-error`), server
+ * components, server actions, and middleware.
+ *
+ * This is the framework-level hook, so individual routes do NOT need any
+ * explicit error-capture code.
+ *
+ * See: https://posthog.com/docs/error-tracking/installation/nextjs
+ */
+export const onRequestError: Instrumentation.onRequestError = async (
+  err,
+  request,
+  context
+) => {
+  // Skip the edge runtime — posthog-node targets Node.js and we only wire
+  // the API routes through Node anyway.
+  if (process.env.NEXT_RUNTIME !== 'nodejs') {
+    return;
+  }
+
+  // Use require() so the posthog-node module (and its transitive deps) are
+  // only loaded on Node, never in the edge bundle.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { getPostHogServer } = require('./lib/posthogServer') as typeof import('./lib/posthogServer');
+  const posthog = getPostHogServer();
+  if (!posthog) {
+    // No PostHog key configured — nothing to do.
+    return;
+  }
+
+  // Best-effort distinct_id: read from the PostHog browser cookie if present.
+  let distinctId: string | undefined;
+  const cookieHeader = request.headers.cookie;
+  if (cookieHeader) {
+    const cookieString = Array.isArray(cookieHeader) ? cookieHeader.join('; ') : cookieHeader;
+    const postHogCookieMatch = cookieString.match(/ph_phc_.*?_posthog=([^;]+)/);
+    if (postHogCookieMatch && postHogCookieMatch[1]) {
+      try {
+        const decodedCookie = decodeURIComponent(postHogCookieMatch[1]);
+        const postHogData = JSON.parse(decodedCookie);
+        if (typeof postHogData?.distinct_id === 'string') {
+          distinctId = postHogData.distinct_id;
+        }
+      } catch {
+        // Ignore malformed cookies — we'll just capture without a distinct_id.
+      }
+    }
+  }
+
+  // captureExceptionImmediate bypasses the batching queue and resolves only
+  // after the request has been flushed — critical in serverless environments
+  // (Vercel) where the process may be suspended before the next flush.
+  await posthog.captureExceptionImmediate(err, distinctId, {
+    $current_url: request.path,
+    $request_method: request.method,
+    route: context.routePath,
+    routeType: context.routeType,
+    routerKind: context.routerKind,
+  });
+};

--- a/src/lib/posthogServer.ts
+++ b/src/lib/posthogServer.ts
@@ -1,0 +1,39 @@
+import { PostHog } from 'posthog-node';
+
+let posthogInstance: PostHog | null = null;
+
+/**
+ * Returns a singleton PostHog Node client for server-side error capture.
+ *
+ * flushAt/flushInterval are set to 1/0 so that events are sent immediately.
+ * This matters in serverless environments (e.g. Vercel) where the process
+ * can be suspended before a batched flush happens.
+ *
+ * Returns null when NEXT_PUBLIC_POSTHOG_KEY is not configured so callers
+ * can short-circuit without throwing during local/test runs.
+ */
+export function getPostHogServer(): PostHog | null {
+  if (posthogInstance) {
+    return posthogInstance;
+  }
+
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!key) {
+    return null;
+  }
+
+  posthogInstance = new PostHog(key, {
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    flushAt: 1,
+    flushInterval: 0,
+  });
+
+  return posthogInstance;
+}
+
+/**
+ * Test-only helper to reset the singleton between tests.
+ */
+export function __resetPostHogServerForTests(): void {
+  posthogInstance = null;
+}

--- a/src/tests/instrumentation.test.ts
+++ b/src/tests/instrumentation.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment node
+ */
+
+const captureExceptionImmediate = jest.fn().mockResolvedValue(undefined);
+const getPostHogServerMock = jest.fn();
+
+jest.mock('../lib/posthogServer', () => ({
+  getPostHogServer: getPostHogServerMock,
+  __resetPostHogServerForTests: jest.fn(),
+}));
+
+import type { Instrumentation } from 'next';
+import { onRequestError } from '../instrumentation';
+
+type ErrorRequest = Parameters<Instrumentation.onRequestError>[1];
+type ErrorContext = Parameters<Instrumentation.onRequestError>[2];
+
+const baseRequest: ErrorRequest = {
+  path: '/api/test-error',
+  method: 'GET',
+  headers: {},
+};
+
+const baseContext: ErrorContext = {
+  routerKind: 'App Router',
+  routePath: '/api/test-error',
+  routeType: 'route',
+  revalidateReason: undefined,
+};
+
+describe('instrumentation onRequestError', () => {
+  const originalRuntime = process.env.NEXT_RUNTIME;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_RUNTIME = 'nodejs';
+    getPostHogServerMock.mockReturnValue({ captureExceptionImmediate });
+  });
+
+  afterAll(() => {
+    process.env.NEXT_RUNTIME = originalRuntime;
+  });
+
+  it('forwards errors from the /api/test-error route to PostHog', async () => {
+    const err = new Error('Intentional server-side test error');
+
+    await onRequestError(err, baseRequest, baseContext);
+
+    expect(captureExceptionImmediate).toHaveBeenCalledTimes(1);
+    expect(captureExceptionImmediate).toHaveBeenCalledWith(
+      err,
+      undefined,
+      expect.objectContaining({
+        $current_url: '/api/test-error',
+        $request_method: 'GET',
+        route: '/api/test-error',
+        routeType: 'route',
+        routerKind: 'App Router',
+      })
+    );
+  });
+
+  it('extracts a distinct_id from the PostHog browser cookie when present', async () => {
+    const cookieValue = encodeURIComponent(
+      JSON.stringify({ distinct_id: 'user_abc_123' })
+    );
+    const request: ErrorRequest = {
+      ...baseRequest,
+      headers: {
+        cookie: `foo=bar; ph_phc_testproject_posthog=${cookieValue}; baz=qux`,
+      },
+    };
+
+    await onRequestError(new Error('boom'), request, baseContext);
+
+    expect(captureExceptionImmediate).toHaveBeenCalledWith(
+      expect.any(Error),
+      'user_abc_123',
+      expect.any(Object)
+    );
+  });
+
+  it('still captures the error when the PostHog cookie is malformed', async () => {
+    const request: ErrorRequest = {
+      ...baseRequest,
+      headers: {
+        cookie: 'ph_phc_testproject_posthog=not-valid-json',
+      },
+    };
+
+    await onRequestError(new Error('boom'), request, baseContext);
+
+    expect(captureExceptionImmediate).toHaveBeenCalledTimes(1);
+    expect(captureExceptionImmediate).toHaveBeenCalledWith(
+      expect.any(Error),
+      undefined,
+      expect.any(Object)
+    );
+  });
+
+  it('does nothing when running in the edge runtime', async () => {
+    process.env.NEXT_RUNTIME = 'edge';
+
+    await onRequestError(new Error('boom'), baseRequest, baseContext);
+
+    expect(getPostHogServerMock).not.toHaveBeenCalled();
+    expect(captureExceptionImmediate).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when PostHog is not configured (no key)', async () => {
+    getPostHogServerMock.mockReturnValue(null);
+
+    await onRequestError(new Error('boom'), baseRequest, baseContext);
+
+    expect(captureExceptionImmediate).not.toHaveBeenCalled();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1864,6 +1864,11 @@
   dependencies:
     cross-spawn "^7.0.6"
 
+"@posthog/core@1.25.2":
+  version "1.25.2"
+  resolved "https://registry.yarnpkg.com/@posthog/core/-/core-1.25.2.tgz#94a7b7ae44739fa945eaf688126f9af3435473d7"
+  integrity sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==
+
 "@posthog/types@1.362.0":
   version "1.362.0"
   resolved "https://registry.yarnpkg.com/@posthog/types/-/types-1.362.0.tgz#024d2560e5dacae01e4c4eff63d7287704c04432"
@@ -6375,6 +6380,13 @@ posthog-js@^1.362.0:
     preact "^10.28.2"
     query-selector-shadow-dom "^1.0.1"
     web-vitals "^5.1.0"
+
+posthog-node@^5.29.2:
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/posthog-node/-/posthog-node-5.29.2.tgz#081394948c1c7dd9b13f2838d31b09585da4802c"
+  integrity sha512-rI7kkF0XqDc0G1qjx+Hb4iuY9NAlL+XQNoGOpnEpRNTUcXvjY6WlsRGZ9m2whgc39emrrYdszi/YT8wZkr2xsg==
+  dependencies:
+    "@posthog/core" "1.25.2"
 
 preact-render-to-string@^5.1.19:
   version "5.2.6"


### PR DESCRIPTION
Supersedes #388.

## Summary

- Adds `posthog-node` dependency
- Adds `src/lib/posthogServer.ts` singleton (flushAt:1/flushInterval:0 for serverless)
- Adds `src/instrumentation.ts` with `register()` + `onRequestError` — Next.js 15 calls this automatically for all unhandled server errors (route handlers, server components, server actions, middleware). No per-route code needed.
- Extracts distinct_id from PostHog browser cookie when available
- Uses `captureExceptionImmediate` for reliable capture in serverless environments

## Test plan

- [x] 5 unit tests pass (error forwarding, cookie parsing, malformed cookie, edge runtime skip, missing key guard)
- [x] `yarn test` — all 539 tests pass
- [x] `yarn dev` + `curl /api/test-error` — confirmed real `POST /batch/` request from posthog-node reaches PostHog host

## Visual Verification

- Visited `/test-error` page — renders correctly (HTTP 200)
- Clicked "Invoke server-side error endpoint" — returns 500 and PostHog receives the error event (verified via netcat listener capturing the `/batch/` POST)

## Dev Server Issues

- `yarn lint` has a pre-existing failure (`@next/next/no-html-link-for-pages` rule error) unrelated to this PR — caused by the Next.js 15 upgrade in #369

https://claude.ai/code/session_017i3wBenq59TVCYm7Y3ppVa