### PR TITLE
docs: require fixture deck URL for deck builder visual verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ All PRs from automated agents MUST include:
 - A `## Visual Verification` section in the PR body describing which pages were visited and what was confirmed
 - If the dev server or browser fails, a `## Dev Server Issues` section with the full error output (do NOT skip or omit this step)
 
+When verifying changes to the deck builder (`/decks`), always visit `/decks?fixture=1` — this loads a pre-populated fixture deck (see `src/lib/practiceDeck.ts` and the fixture handling in `src/components/DeckBuilderClient.tsx`) so you can verify UI that depends on cards being present (analysis tabs, card lists, mission selectors, charts, etc.). Visiting `/decks` alone shows only the empty state. The fixture URL bypasses authentication and localStorage, so no login or saved deck is required.
+
 ## Fixing bugs
 When asked to fix a bug do your best to write a test that fails without the bug fix. Weigh up the cost and brittleness of writing the test and comment in the PR with the circumstances that made you feel like you couldn't write a useful test. 
 


### PR DESCRIPTION
## Summary

Closes #396.

Adds a note to the PR Requirements section of `AGENTS.md` instructing agents that, when verifying changes to the deck builder, they must visit `/decks?fixture=1` instead of plain `/decks` so a pre-populated deck is rendered. Without this, agents cannot verify any UI that depends on having deck data (analysis tabs, card lists, mission selectors, attribute charts, etc.).

The fixture URL already exists (`PRACTICE_DECK_TSV` in `src/lib/practiceDeck.ts`, handled by `src/components/DeckBuilderClient.tsx`) and bypasses authentication and localStorage, so no code changes are needed.

## Visual Verification

This PR is documentation-only — no application code or rendered UI changed, so there is nothing to verify in a browser. The dev server was not started for this change because the modification is limited to a single Markdown file and no front-end behavior is affected.

## Test plan

- [x] Confirm the new guidance appears in `AGENTS.md` under the PR Requirements section
- [x] Confirm no other files were modified

https://claude.ai/code/session_01LDph7hgM8qaSuYQ14MTXXK